### PR TITLE
use --module option

### DIFF
--- a/bin/romi_run_task
+++ b/bin/romi_run_task
@@ -51,7 +51,6 @@ def parsing():
                                      """.format(HELP_URL))
 
     parser.add_argument('task', metavar='task', type=str,
-                        choices=TASKS,
                         help=f"Luigi task to run: {', '.join(TASKS)}")
 
     parser.add_argument('db_path', metavar='dataset_path', type=str,
@@ -151,11 +150,14 @@ if __name__ == "__main__":
     else:
         print("Using a PREVIOUS configuration.")
 
-    # TODO: Not really sure what happens here...
+    # Set the module to be loaded for the task. 
     if args.module is not None:
         module = args.module
-    else:
+    elif args.task in MODULES:
         module = MODULES[args.task]
+    else:
+        raise ValueError("No module was defined for the task '%s'" % args.task)
+        
 
     # Handle datasets directory:
     #  - if a "Scan" or "VirtualScan" tasks is required, a directory should be created

--- a/bin/romi_run_task
+++ b/bin/romi_run_task
@@ -51,7 +51,7 @@ def parsing():
                                      """.format(HELP_URL))
 
     parser.add_argument('task', metavar='task', type=str,
-                        help=f"Luigi task to run: {', '.join(TASKS)}")
+                        help=f"Luigi task to run. The list of pre-defined is: {', '.join(TASKS)}")
 
     parser.add_argument('db_path', metavar='dataset_path', type=str,
                         help='FSDB scan dataset to process (path)')
@@ -156,9 +156,11 @@ if __name__ == "__main__":
     elif args.task in MODULES:
         module = MODULES[args.task]
     else:
-        raise ValueError("No module was defined for the task '%s'" % args.task)
+        print(f"WARNING: No module was defined for the task '{args.task}'" )
+        print(f"WARNING: The list of pre-defined tasks is: {', '.join(TASKS)}" )
+        print(f"WARNING: For other tasks, use the --module option to load the module containing the task")
+        raise ValueError(f"No module was defined for the task '{args.task}'")
         
-
     # Handle datasets directory:
     #  - if a "Scan" or "VirtualScan" tasks is required, a directory should be created
     #  - else, check it exists


### PR DESCRIPTION
close #192 

The --module option was partially ignored because the parsing of the 'task' argument limited the possible values to the list of predefined names in the MODULES variable. The changes allow to run a task that is part of a module that is not in this default list. For example, it allows to run the tasks in the module romiscan.tasks.evaluation (evaluation.py).

