### PR TITLE
Refactor Segmentation2DEvaluation + compute intersection-over-union, add requirements for 3D evaluation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-# pywavefront  # Changed to optional as only used in romiscan/romiscan/tasks/evaluation.py
-# trimesh  # Changed to optional as only used once in romiscan/romiscan/tasks/evaluation.py
 appdirs
 colorlog
 cython

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,5 @@ pyopencl== 2020.2.2
 scikit-image
 toml>= 0.10.2
 tqdm
+pywavefront
+trimesh

--- a/romiscan/tasks/evaluation.py
+++ b/romiscan/tasks/evaluation.py
@@ -15,6 +15,7 @@ from romiscan.tasks import config
 from romiscan.tasks import proc2d
 from romiscan.tasks import proc3d
 from romiscanner.tasks.lpy import VirtualPlant
+from romiscanner.tasks.scan import ObjFileset
 
 
 class EvaluationTask(RomiTask):
@@ -272,84 +273,91 @@ class Segmentation2DEvaluation(EvaluationTask):
     upstream_task = luigi.TaskParameter(default=proc2d.Segmentation2D)
     ground_truth = luigi.TaskParameter(default=ImagesFilesetExists)
     hist_bins = luigi.IntParameter(default=100)
-    tol_px = luigi.IntParameter()
+    tol_px = luigi.IntParameter(default=0)
 
     def evaluate(self):
+        self.prediction_fileset = self.upstream_task().output().get()
+        self.ground_truth_fileset = self.ground_truth().output().get()
+        return self.compare_predictions_to_ground_truths()
+
+    def compare_predictions_to_ground_truths(self):
+        results = {}
+        labels = self.get_labels_to_compare()
+        for label in labels:
+            results[label] = self.compare_label(label)
+        return results
+
+    def get_labels_to_compare(self):
+        labels = self.ground_truth_fileset.get_metadata('channels')
+        if 'rgb' in labels:
+            labels.remove('rgb')
+        if 'background' in labels:
+            labels.remove('background')
+        return labels
+
+    def compare_label(self, label):
+        prediction_files = self.get_prediction_files(label)
+        results = { 'tp': 0, 'fp': 0, 'tn': 0, 'fn': 0 }
+
+        for prediction_file in prediction_files:
+            tp, fn, tn, fp = self.evaluate_prediction(prediction_file, label)
+            results['tp'] += tp
+            results['fp'] += fp
+            results['tn'] += tn
+            results['fn'] += fn
+
+        self.compute_precision_and_recall(results)
+        self.compute_intersection_over_union(results)
+        return results
+
+    def compute_precision_and_recall(self, results):
+        results['precision'] = results['tp'] / (results['tp'] + results['fp'])
+        if results['tp'] + results['fn'] == 0:
+            results['recall'] = 'undefined'
+        else:
+            results['recall'] = results['tp'] / (results['tp'] + results['fn'])
+
+    def compute_intersection_over_union(self, results):
+        results['iou'] = ((results['tp'] + results['tn'])
+                          / (results['tp'] + results['tn']
+                             + results['fp'] + results['fn']))
+
+    def get_prediction_files(self, label):
+        return self.prediction_fileset.get_files(query={'channel': label})
+
+    def evaluate_prediction(self, prediction_file, label):
+        im_prediction = self.load_prediction_image(prediction_file)
+        im_gt = self.load_ground_truth_image(label, prediction_file)
+        im_gt_tol = self.dilate_image(im_gt, self.tol_px)
+        tp = int(np.sum(im_gt_tol * (im_prediction > 0)))
+        fn = int(np.sum(im_gt_tol * (im_prediction == 0)))
+        tn = int(np.sum((im_gt == 0) * (im_prediction == 0)))
+        fp = int(np.sum((im_gt == 0) * (im_prediction > 0)))
+        return tp, fn, tn, fp
+
+    def load_ground_truth_image(self, label, prediction_file):
+        ground_truth_file = self.get_ground_truth_file(label, prediction_file)
+        image_gt = self.read_binary_image(ground_truth_file)
+        return image_gt
+
+    def get_ground_truth_file(self, label, prediction_file):
+        shot_id = prediction_file.get_metadata('shot_id')
+        query = {'channel': label, 'shot_id': shot_id}
+        files = self.ground_truth_fileset.get_files(query=query)
+        return files[0]
+
+    def read_binary_image(self, file_obj):
+        image = io.read_image(file_obj)
+        return (image > 0).astype(np.int)
+
+    def dilate_image(self, image, tolerance):
         from scipy.ndimage.morphology import binary_dilation
+        for i in range(self.tol_px):
+            image = binary_dilation(image > 0)
+        return image
 
-        prediction_fileset = self.upstream_task().output().get()
-        gt_fileset = self.ground_truth().output().get()
-        channels = gt_fileset.get_metadata('channels')
-        channels.remove('rgb')
-
-        histograms = {}
-        res = {}
-
-        for c in channels:
-
-            if (c == "background"):
-                continue
-
-            preds = prediction_fileset.get_files(query={'channel': c})
-            # hist_high, disc = np.histogram(np.array([]), self.hist_bins, range=(0,1))
-            # hist_low, disc = np.histogram(np.array([]), self.hist_bins, range=(0,1))
-            res[c] = {
-                "tp": 0,
-                "fp": 0,
-                "tn": 0,
-                "fn": 0
-            }
-
-            for pred in preds:
-                ground_truth = gt_fileset.get_files(query={'channel': c,
-                                                           'shot_id': pred.get_metadata(
-                                                               'shot_id')})[0]
-                im_pred = io.read_image(pred)
-                im_gt = io.read_image(ground_truth)
-                for i in range(self.tol_px):
-                    im_gt_tol = binary_dilation(im_gt > 0)
-
-                tp = int(np.sum(im_gt_tol * (im_pred > 0)))
-                fn = int(np.sum(im_gt_tol * (im_pred == 0)))
-                tn = int(np.sum((im_gt == 0) * (im_pred == 0)))
-                fp = int(np.sum((im_gt == 0) * (im_pred > 0)))
-
-                res[c]["tp"] += tp
-                res[c]["fp"] += fp
-                res[c]["tn"] += tn
-                res[c]["fn"] += fn
-
-            #         if c == "background":
-            #             threshold = 254
-            #         else:
-            #             threshold = 0
-
-            #         res[c]["tp"] += int(np.sum((im_gt > threshold) * (im_pred > 128)))
-            #         res[c]["fp"] += int(np.sum((im_gt <= threshold) * (im_pred > 128)))
-            #         res[c]["tn"] += int(np.sum((im_gt <= threshold) * (im_pred <= 128)))
-            #         res[c]["fn"] += int(np.sum((im_gt > threshold) * (im_pred <= 128)))
-
-            #         # im_gt_high = im_pred[im_gt > threshold] / 255
-            #         # im_gt_low = im_pred[1-im_gt < threshold] / 255
-
-            #         # hist_high_pred, bins_high = np.histogram(im_gt_high, self.hist_bins, range=(0,1))
-            #         # hist_low_pred, bins_low = np.histogram(im_gt_low, self.hist_bins, range=(0,1))
-            #         # hist_high += hist_high_pred
-            #         # hist_low += hist_low_pred
-            #     if res[c]["tp"] + res[c]["fp"] == 0:
-            #         res.pop(c, None)
-            #         continue
-
-            res[c]["precision"] = res[c]["tp"] / (res[c]["tp"] + res[c]["fp"])
-
-            if res[c]["tp"] + res[c]["fn"] == 0:
-                res.pop(c, None)
-                continue
-
-            res[c]["recall"] = res[c]["tp"] / (res[c]["tp"] + res[c]["fn"])
-        #     # histograms[c] = {"hist_high": hist_high.tolist(), "bins_high": bins_high.tolist(), "hist_low": hist_low.tolist(), "bins_low": bins_low.tolist()}
-        # # return histograms
-        return res
+    def load_prediction_image(self, prediction):
+        return self.read_binary_image(prediction)
 
 
 class VoxelsEvaluation(EvaluationTask):

--- a/romiscan/tasks/evaluation.py
+++ b/romiscan/tasks/evaluation.py
@@ -300,23 +300,28 @@ class Segmentation2DEvaluation(EvaluationTask):
         results = { 'tp': 0, 'fp': 0, 'tn': 0, 'fn': 0, 'miou': 0.0 }
 
         for prediction_file in prediction_files:
-            tp, fn, tn, fp = self.evaluate_prediction(prediction_file, label)
-            results['tp'] += tp
-            results['fp'] += fp
-            results['tn'] += tn
-            results['fn'] += fn
-            if tp + fp + fn > 0:
-                results['miou'] += tp / (tp + fp + fn)
-            else:
-                logger.warning("Can't compute IoU for label '%s' and file '%s'"
-                               % (label, prediction_file.filename))
+            self.update_results(results, prediction_file, label)
                 
-        if len(prediction_files) > 0:
-            results['miou'] /= len(prediction_files)
-            
+        self.average_miou(results, len(prediction_files))
         self.compute_precision_and_recall(results)
         return results
 
+    def update_results(self, results, prediction_file, label):
+        tp, fn, tn, fp = self.evaluate_prediction(prediction_file, label)
+        results['tp'] += tp
+        results['fp'] += fp
+        results['tn'] += tn
+        results['fn'] += fn
+        if tp + fp + fn > 0:
+            results['miou'] += tp / (tp + fp + fn)
+        else:
+            logger.warning("Can't compute IoU for label '%s' and file '%s'"
+                           % (label, prediction_file.filename))
+
+    def average_miou(self, results, num):
+        if num > 0:
+            results['miou'] /= num
+            
     def compute_precision_and_recall(self, results):
         results['precision'] = results['tp'] / (results['tp'] + results['fp'])
         if results['tp'] + results['fn'] == 0:

--- a/romiscan/tasks/evaluation.py
+++ b/romiscan/tasks/evaluation.py
@@ -297,12 +297,12 @@ class Segmentation2DEvaluation(EvaluationTask):
 
     def compare_label(self, label):
         prediction_files = self.get_prediction_files(label)
-        results = { 'tp': 0, 'fp': 0, 'tn': 0, 'fn': 0, 'miou': 0.0 }
+        results = { 'tp': 0, 'fp': 0, 'tn': 0, 'fn': 0, 'miou': 0.0, 'images': 0 }
 
         for prediction_file in prediction_files:
             self.update_results(results, prediction_file, label)
                 
-        self.average_miou(results, len(prediction_files))
+        self.average_miou(results)
         self.compute_precision_and_recall(results)
         return results
 
@@ -314,13 +314,14 @@ class Segmentation2DEvaluation(EvaluationTask):
         results['fn'] += fn
         if tp + fp + fn > 0:
             results['miou'] += tp / (tp + fp + fn)
+            results['images'] += 1
         else:
             logger.warning("Can't compute IoU for label '%s' and file '%s'"
                            % (label, prediction_file.filename))
 
-    def average_miou(self, results, num):
-        if num > 0:
-            results['miou'] /= num
+    def average_miou(self, results):
+        if results['images'] > 0:
+            results['miou'] /= results['images']
             
     def compute_precision_and_recall(self, results):
         results['precision'] = results['tp'] / (results['tp'] + results['fp'])


### PR DESCRIPTION
close #191 

This PR contains mostly a refactoring of the Segmentation2DEvaluation task.

In addition:
- It add the computation of the intersection-over-union (IoU) in the evaluation
- It also addss the two Python libraries that are required by VoxelGroundTruth (called by VoxelsEvaluation) to requirements.txt:  pywavefront and trimesh