### PR TITLE
Refactoring of 'set' metrics

### DIFF
--- a/romiscan/metrics.py
+++ b/romiscan/metrics.py
@@ -86,10 +86,11 @@ def point_cloud_registration_fitness(ref_pcd, flo_pcd, max_distance=2):
     res = o3d.pipelines.registration.evaluate_registration(ref_pcd, flo_pcd, max_distance)
     return res.fitness, res.inlier_rmse
 
+
 class SetMetrics():
-    """Compare two binary masks as sets. Non-binary masks can be passed as
-    argument. Any value equal to zero will be considered as zero,
-    any value > 0 will be considered as 1.
+    """Compare two arrays as sets. Non-binary arrays can be passed as
+    argument. Any value equal to zero will be considered as zero, any
+    value > 0 will be considered as 1.
     
         Parameters
         ----------
@@ -122,6 +123,7 @@ class SetMetrics():
     >>>     prediction_mask = imageio.imread(prediction_file)
     >>>     metrics.add(groundtruth_mask, prediction_mask)
     >>> print(metrics)
+
     """
 
     def __init__(self, groundtruth=None, prediction=None):
@@ -202,7 +204,7 @@ class SetMetrics():
             value = self._miou / self._miou_count
         return value
 
-
+    
 def surface_ratio(ref_tmesh, flo_tmesh):
     """Returns the min/max surface ratio of two triangular meshes.
 

--- a/romiscan/metrics.py
+++ b/romiscan/metrics.py
@@ -185,19 +185,19 @@ class SetMetrics():
             self._miou_count += 1
 
     def precision(self):
-        value = 0.0
+        value = None
         if (self.tp + self.fp) != 0:
             value = self.tp / (self.tp + self.fp)
         return value
 
     def recall(self):
-        value = 0.0
+        value = None
         if (self.tp + self.fn) != 0:
             value = self.tp / (self.tp + self.fn)
         return value
 
     def miou(self):
-        value = 0.0
+        value = None
         if self._miou_count > 0:
             value = self._miou / self._miou_count
         return value

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,80 @@
+import unittest
+import numpy as np
+import sys
+
+#sys.path.append("..")
+from romiscan.metrics import SetMetrics
+
+class TestSetMetrics(unittest.TestCase):
+    square_left = np.array([[1, 1, 0, 0],
+                            [1, 255, 0, 0]],
+                           np.uint8)
+    square_center = np.array([[0, 1, 255, 0],
+                              [0, 1, 1, 0]],
+                             np.uint8)
+    square_right = np.array([[0, 0, 1, 1],
+                             [0, 0, 255, 1]],
+                            np.uint8)
+    square_left_float = np.array([[0.1, 0.1, 0, 0],
+                                  [0.1, 0.1, 0, 0]],
+                                 np.float32)
+    square_center_float = np.array([[0, 0.1, 0.1, 0],
+                                    [0, -0.1, 0.1, 0]],
+                                   np.float32)
+
+    def test_compare_idential_masks(self):
+        metrics = SetMetrics()
+        metrics.compare(self.square_left, self.square_left)
+        assert(metrics.tp == 4)
+        assert(metrics.fn == 0)
+        assert(metrics.tn == 4)
+        assert(metrics.fp == 0)
+        assert(metrics.precision() == 1.0)
+        assert(metrics.recall() == 1.0)
+        assert(metrics.miou() == 1.0)
+
+    def test_compare_masks_without_intersection(self):
+        metrics = SetMetrics()
+        metrics.compare(self.square_left, self.square_right)
+        assert(metrics.tp == 0)
+        assert(metrics.fn == 4)
+        assert(metrics.tn == 0)
+        assert(metrics.fp == 4)
+        assert(metrics.precision() == 0.0)
+        assert(metrics.recall() == 0.0)
+        assert(metrics.miou() == 0.0)
+
+    def test_compare_masks_with_partial_overlap(self):
+        metrics = SetMetrics()
+        metrics.compare(self.square_left, self.square_center)
+        assert(metrics.tp == 2)
+        assert(metrics.fn == 2)
+        assert(metrics.tn == 2)
+        assert(metrics.fp == 2)
+        assert(metrics.precision() == 0.5)
+        assert(metrics.recall() == 0.5)
+        assert(metrics.miou() == 2.0/6.0)
+
+    def test_multiple_compares(self):
+        metrics = SetMetrics()
+        metrics.compare(self.square_left, self.square_left)
+        metrics.compare(self.square_left, self.square_right)
+        metrics.compare(self.square_left, self.square_center)
+        assert(metrics.tp == 6)
+        assert(metrics.fn == 6)
+        assert(metrics.tn == 6)
+        assert(metrics.fp == 6)
+        assert(metrics.precision() == 0.5)
+        assert(metrics.recall() == 0.5)
+        assert(metrics.miou() == (1.0 + 0.0 + 2.0/6.0) / 3)
+
+    def test_compare_floating_point_arrays(self):
+        metrics = SetMetrics()
+        metrics.compare(self.square_left_float, self.square_center_float)
+        assert(metrics.tp == 2)
+        assert(metrics.fn == 2)
+        assert(metrics.tn == 2)
+        assert(metrics.fp == 2)
+        assert(metrics.precision() == 0.5)
+        assert(metrics.recall() == 0.5)
+        assert(metrics.miou() == 2.0/6.0)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -2,7 +2,7 @@ import unittest
 import numpy as np
 import sys
 
-#sys.path.append("..")
+sys.path.append("..")
 from romiscan.metrics import SetMetrics
 
 class TestSetMetrics(unittest.TestCase):
@@ -23,8 +23,7 @@ class TestSetMetrics(unittest.TestCase):
                                    np.float32)
 
     def test_compare_idential_masks(self):
-        metrics = SetMetrics()
-        metrics.compare(self.square_left, self.square_left)
+        metrics = SetMetrics(self.square_left, self.square_left)
         assert(metrics.tp == 4)
         assert(metrics.fn == 0)
         assert(metrics.tn == 4)
@@ -34,8 +33,7 @@ class TestSetMetrics(unittest.TestCase):
         assert(metrics.miou() == 1.0)
 
     def test_compare_masks_without_intersection(self):
-        metrics = SetMetrics()
-        metrics.compare(self.square_left, self.square_right)
+        metrics = SetMetrics(self.square_left, self.square_right)
         assert(metrics.tp == 0)
         assert(metrics.fn == 4)
         assert(metrics.tn == 0)
@@ -45,8 +43,7 @@ class TestSetMetrics(unittest.TestCase):
         assert(metrics.miou() == 0.0)
 
     def test_compare_masks_with_partial_overlap(self):
-        metrics = SetMetrics()
-        metrics.compare(self.square_left, self.square_center)
+        metrics = SetMetrics(self.square_left, self.square_center)
         assert(metrics.tp == 2)
         assert(metrics.fn == 2)
         assert(metrics.tn == 2)
@@ -57,9 +54,9 @@ class TestSetMetrics(unittest.TestCase):
 
     def test_multiple_compares(self):
         metrics = SetMetrics()
-        metrics.compare(self.square_left, self.square_left)
-        metrics.compare(self.square_left, self.square_right)
-        metrics.compare(self.square_left, self.square_center)
+        metrics.add(self.square_left, self.square_left)
+        metrics.add(self.square_left, self.square_right)
+        metrics.add(self.square_left, self.square_center)
         assert(metrics.tp == 6)
         assert(metrics.fn == 6)
         assert(metrics.tn == 6)
@@ -68,9 +65,32 @@ class TestSetMetrics(unittest.TestCase):
         assert(metrics.recall() == 0.5)
         assert(metrics.miou() == (1.0 + 0.0 + 2.0/6.0) / 3)
 
+    def test_adding_metrics(self):
+        m1 = SetMetrics(self.square_left, self.square_left)
+        m2 = SetMetrics(self.square_left, self.square_right)
+        m3 = SetMetrics(self.square_left, self.square_center)
+        m1 += m2
+        m1 += m3
+        assert(m1.tp == 6)
+        assert(m1.fn == 6)
+        assert(m1.tn == 6)
+        assert(m1.fp == 6)
+        assert(m1.precision() == 0.5)
+        assert(m1.recall() == 0.5)
+        assert(m1.miou() == (1.0 + 0.0 + 2.0/6.0) / 3)
+
     def test_compare_floating_point_arrays(self):
-        metrics = SetMetrics()
-        metrics.compare(self.square_left_float, self.square_center_float)
+        metrics = SetMetrics(self.square_left_float, self.square_center_float)
+        assert(metrics.tp == 2)
+        assert(metrics.fn == 2)
+        assert(metrics.tn == 2)
+        assert(metrics.fp == 2)
+        assert(metrics.precision() == 0.5)
+        assert(metrics.recall() == 0.5)
+        assert(metrics.miou() == 2.0/6.0)
+
+    def test_mixing_int_and_floating_point_arrays(self):
+        metrics = SetMetrics(self.square_left, self.square_center_float)
         assert(metrics.tp == 2)
         assert(metrics.fn == 2)
         assert(metrics.tn == 2)

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -98,3 +98,13 @@ class TestSetMetrics(unittest.TestCase):
         assert(metrics.precision() == 0.5)
         assert(metrics.recall() == 0.5)
         assert(metrics.miou() == 2.0/6.0)
+
+    def test_uninitilized_metrics_returns_zeros_and_none(self):
+        metrics = SetMetrics()
+        assert(metrics.tp == 0)
+        assert(metrics.fn == 0)
+        assert(metrics.tn == 0)
+        assert(metrics.fp == 0)
+        assert(metrics.precision() == None)
+        assert(metrics.recall() == None)
+        assert(metrics.miou() == None)


### PR DESCRIPTION
This is a refactoring of the set_metrics function (not used in the current code). It was converted into a class so it can provide an additional metric, the intersection-over-union. It can also be called several times in a sequence to accumulate the values of true positives, false positives, ... and to computer the mean intersection-over-union (mIoU).



