### PR TITLE
Add `vol2pcd_mc` function and enhance point cloud utilities

### DIFF
--- a/configs/geom_pipe_full.toml
+++ b/configs/geom_pipe_full.toml
@@ -129,8 +129,10 @@ z = [-125, 100]
 [PointCloud]
 # Task that provides the voxel array as input
 upstream_task = "Voxels"  # Default: "Voxels"
+# The algorithm to use to compute the pointcloud
+algorithm = "marching-cubes"  # Default: "marching-cubes"
 # Distance of the level set on which the points are sampled
-level_set_value = 1.0  # Default: 1.0
+level_set_value = 0.0  # Default: 1.0
 # Threshold for the number of missing images allowed in the reconstructed volume
 missing_images_threshold = 2  # Default: 2
 # List of labels to use for multi-class point cloud generation
@@ -144,6 +146,10 @@ min_contrast = 10.0  # Default: 10.0
 # Minimum score threshold for points in multi-class segmentation
 # Only used if labels are defined (multi-class)
 min_score = 0.2  # Default: 0.2
+# Standard deviation for Gaussian kernel (only for marching-cubes)
+sigma = 0.8
+# Level set value for the marching cubes algorithm
+mc_level = 0.5
 
 [TriangleMesh]
 # Task that provides the point cloud as input

--- a/configs/geom_pipe_real.toml
+++ b/configs/geom_pipe_real.toml
@@ -76,8 +76,14 @@ z = [-125, 100]
 [PointCloud]
 # Task that provides the voxel array as input
 upstream_task = "Voxels"  # Default: "Voxels"
+# The algorithm to use to compute the pointcloud
+algorithm = "marching-cubes"  # Default: "marching-cubes"
 # Threshold for the number of missing images allowed in the reconstruction
 missing_images_threshold = 2  # Default: 2
+# Standard deviation for Gaussian kernel (only for marching-cubes)
+sigma = 0.8
+# Level set value for the marching cubes algorithm
+mc_level = 0.5
 
 [TriangleMesh]
 # Task that provides the point cloud as input

--- a/configs/test_geom_pipe_real.toml
+++ b/configs/test_geom_pipe_real.toml
@@ -44,6 +44,9 @@ z = [-175, 105]
 [PointCloud]
 upstream_task = "Voxels"
 missing_images_threshold = 2  # Default: 2
+algorithm = "marching-cubes"  # Default: "marching-cubes"
+sigma = 0.8
+mc_level = 0.5
 
 [TriangleMesh]
 upstream_task = "PointCloud"

--- a/plant3dvision/proc3d.py
+++ b/plant3dvision/proc3d.py
@@ -8,11 +8,15 @@ plant3dvision.proc3d
 This module contains all functions for processing of 3D data.
 
 """
+import time
+
 import networkx as nx
 import numpy as np
 import open3d as o3d
+from scipy.ndimage import binary_erosion
 from scipy.ndimage.filters import gaussian_filter
-from scipy.ndimage.morphology import distance_transform_edt
+from scipy.ndimage.morphology import distance_transform_edt, binary_dilation
+from skimage import measure
 from skimage.exposure import rescale_intensity
 from tqdm import tqdm
 
@@ -786,6 +790,7 @@ def vol2pcd(volume, origin, voxel_size, level_set_value=0):
     >>> from plantdb.commons.test_database import test_database
     >>> db = test_database()
     >>> db.connect()
+    >>> db.login('admin', 'admin')
     >>> scan = db.get_scan("real_plant_analyzed")
     >>> vol_fs_id = compute_fileset_matches(scan)["Voxels"]
     >>> vol_fs = scan.get_fileset(vol_fs_id)
@@ -799,7 +804,6 @@ def vol2pcd(volume, origin, voxel_size, level_set_value=0):
     >>> o3d.visualization.draw_geometries([pcd])
     >>> db.disconnect()
     """
-    import time
     start_time = time.time()
 
     step_start = time.time()
@@ -882,6 +886,105 @@ def vol2pcd(volume, origin, voxel_size, level_set_value=0):
 
     logger.info(f"Total execution time: {time.time() - start_time:.2f}s")
     return pcd
+
+def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0):
+    """
+    Generate a point cloud and triangle mesh from a binary volume using marching cubes.
+
+    This function converts a 3D binary volume into a point cloud and a triangle mesh
+    by applying the marching cubes algorithm. The resulting point cloud and mesh
+    are in world coordinates, accounting for voxel size and origin. Optionally, a
+    level set value can be applied to dilate the input volume before processing.
+
+    Parameters
+    ----------
+    volume : numpy.ndarray
+        A 3D binary volume array representing the input data.
+    origin : Sequence[float]
+        The origin of the volume in world coordinates as (x, y, z).
+    voxel_size : float
+        The size of a voxel in world units.
+    level_set_value : float, optional
+        The level set value used to dilate the binary volume before processing.
+        Defaults to 0, which skips the dilation step.
+
+    Returns
+    -------
+    tuple
+        A tuple containing:
+        - pcd (open3d.geometry.PointCloud): The generated point cloud object.
+        - mesh (open3d.geometry.TriangleMesh): The generated triangle mesh object.
+
+    Raises
+    ------
+    ValueError
+        If any of the input parameters are invalid or the processing fails.
+        Examples
+    --------
+    >>> from plant3dvision.proc3d import vol2pcd_mc
+    >>> from plantdb.commons.io import read_volume
+    >>> from plantdb.server.core.utils import compute_fileset_matches
+    >>> from plantdb.commons.test_database import test_database
+    >>> db = test_database()
+    >>> db.connect()
+    >>> db.login('admin', 'admin')
+    >>> scan = db.get_scan("real_plant_analyzed")
+    >>> vol_fs_id = compute_fileset_matches(scan)["Voxels"]
+    >>> vol_fs = scan.get_fileset(vol_fs_id)
+    >>> vol = read_volume(vol_fs.get_file("Voxels"))
+    >>> print(vol.shape)
+    (301, 301, 561)
+    >>> pcd, mesh = vol2pcd_mc(vol, [0., 0., 0.], 0.5, level_set_value=1.0)
+    >>> print(len(pcd.points))
+    20320
+    >>> import open3d as o3d
+    >>> o3d.visualization.draw_geometries([pcd])
+    >>> db.disconnect()
+    """
+    volume = (volume - np.min(volume)) / np.max(volume - np.min(volume))
+    if level_set_value != 0:
+        logger.info("Computing level set dilation...")
+        _t = time.time()
+        # Convert offset from world units to voxels
+        radius = int(np.round(level_set_value / voxel_size))
+        struct = np.ones((2 * np.abs(radius) + 1,) * 3, dtype=bool)
+        if radius > 0:
+            volume = binary_dilation(volume, structure=struct)
+        elif radius < 0:
+            volume = binary_erosion(volume, structure=struct)
+        logger.info(f"Computing level set dilation... Done in {time.time() - _t:.2f}s")
+
+    # marching_cubes works on a float field; we give it the binary mask.
+    logger.info("Computing marching cubes...")
+    _t = time.time()
+    verts, faces, normals, _ = measure.marching_cubes(
+        volume.astype(np.float32),
+        level=0.5,
+        spacing=(voxel_size, voxel_size, voxel_size)
+    )
+    logger.info(f"Computing marching cubes... Done in {time.time() - _t:.2f}s")
+
+    # Translate to world coordinates
+    verts += np.asarray(origin, dtype=verts.dtype)
+
+    logger.info("Building Open3D PointCloud and Mesh...")
+    _t = time.time()
+    # Build the Open3D point cloud
+    pcd = o3d.geometry.PointCloud()
+    pcd.points = o3d.utility.Vector3dVector(verts)
+    pcd.normals = o3d.utility.Vector3dVector(normals)
+    pcd.normalize_normals()
+
+    # Create empty triangle mesh object
+    mesh = o3d.geometry.TriangleMesh()
+    # Assign vertex coordinates using Open3D's Vector3dVector format
+    mesh.vertices = o3d.utility.Vector3dVector(verts)
+    # Assign triangle face indices using Open3D's Vector3iVector format
+    mesh.triangles = o3d.utility.Vector3iVector(faces)
+    # Assign vertex normals
+    mesh.vertex_normals = o3d.utility.Vector3dVector(normals)
+    logger.info(f"Building Open3D PointCloud and Mesh... Done in {time.time() - _t:.2f}s")
+    return pcd, mesh
 
 
 def crop_point_cloud(point_cloud, bounding_box):

--- a/plant3dvision/proc3d.py
+++ b/plant3dvision/proc3d.py
@@ -17,6 +17,7 @@ import skimage
 from scipy.ndimage import binary_erosion, generate_binary_structure
 from scipy.ndimage.filters import gaussian_filter
 from scipy.ndimage.morphology import distance_transform_edt, binary_dilation
+from scipy.spatial import cKDTree
 from skimage import measure
 from skimage.exposure import rescale_intensity
 from tqdm import tqdm
@@ -1387,3 +1388,34 @@ def pcd_convex_hull_volume(pcd):
 
     convex_hull, _ = pcd.compute_convex_hull()
     return convex_hull.get_volume()
+
+
+def chamfer_distance(pc1: np.ndarray | o3d.geometry.PointCloud, pc2: np.ndarray | o3d.geometry.PointCloud) -> float:
+    """ Compute the symmetric Chamfer distance between two point clouds.
+    Parameters
+    ----------
+    pc1, pc2 : np.ndarray or o3d.geometry.PointCloud
+        Point clouds of shape (N, D) and (M, D) respectively.
+        D is the dimensionality (3 for typical 3?D clouds).
+
+    Returns
+    -------
+    float
+        Mean of the squared nearest?neighbor distances from pc1?pc2
+        plus the mean from pc2?pc1.
+    """
+    # Convert open3d PointCloud to numpy arrays
+    pc1 = np.asarray(pc1.points) if isinstance(pc1, o3d.geometry.PointCloud) else pc1
+    pc2 = np.asarray(pc2.points) if isinstance(pc2, o3d.geometry.PointCloud) else pc2
+
+    # Build KD?trees for fast NN queries
+    tree1 = cKDTree(pc1)
+    tree2 = cKDTree(pc2)
+
+    # Distances from each point in pc1 to its nearest neighbour in pc2
+    d1, _ = tree1.query(pc2, k=1)
+    # Distances from each point in pc2 to its nearest neighbour in pc1
+    d2, _ = tree2.query(pc1, k=1)
+
+    # Chamfer distance = average of squared distances in both directions
+    return float(np.mean(d1 ** 2) + np.mean(d2 ** 2))

--- a/plant3dvision/proc3d.py
+++ b/plant3dvision/proc3d.py
@@ -13,7 +13,8 @@ import time
 import networkx as nx
 import numpy as np
 import open3d as o3d
-from scipy.ndimage import binary_erosion
+import skimage
+from scipy.ndimage import binary_erosion, generate_binary_structure
 from scipy.ndimage.filters import gaussian_filter
 from scipy.ndimage.morphology import distance_transform_edt, binary_dilation
 from skimage import measure
@@ -887,7 +888,7 @@ def vol2pcd(volume, origin, voxel_size, level_set_value=0):
     logger.info(f"Total execution time: {time.time() - start_time:.2f}s")
     return pcd
 
-def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0):
+def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0, sigma=0.5, mc_level=0.5):
     """
     Generate a point cloud and triangle mesh from a binary volume using marching cubes.
 
@@ -907,6 +908,10 @@ def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0):
     level_set_value : float, optional
         The level set value used to dilate the binary volume before processing.
         Defaults to 0, which skips the dilation step.
+    sigma : float, optional
+        Standart deviation for the gaussian filtering prior to marching cubes.
+    mc_level : float, optional
+        Level set for the marching cubes algorithm which sets at which level the surface is. Should be between 0 and 1.
 
     Returns
     -------
@@ -934,7 +939,7 @@ def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0):
     >>> vol = read_volume(vol_fs.get_file("Voxels"))
     >>> print(vol.shape)
     (301, 301, 561)
-    >>> pcd, mesh = vol2pcd_mc(vol, [0., 0., 0.], 0.5, level_set_value=1.0)
+    >>> pcd, mesh = vol2pcd_mc(vol, [0., 0., 0.], 0.5, level_set_value=0.0, sigma=0.8, mc_level=0.2)
     >>> print(len(pcd.points))
     20320
     >>> import open3d as o3d
@@ -947,19 +952,19 @@ def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0):
         _t = time.time()
         # Convert offset from world units to voxels
         radius = int(np.round(level_set_value / voxel_size))
-        struct = np.ones((2 * np.abs(radius) + 1,) * 3, dtype=bool)
+        struct = generate_binary_structure(3, 1)
         if radius > 0:
-            volume = binary_dilation(volume, structure=struct)
+            volume = binary_dilation(volume, structure=struct, iterations=radius)
         elif radius < 0:
-            volume = binary_erosion(volume, structure=struct)
+            volume = binary_erosion(volume, structure=struct, iterations=radius)
         logger.info(f"Computing level set dilation... Done in {time.time() - _t:.2f}s")
 
-    # marching_cubes works on a float field; we give it the binary mask.
     logger.info("Computing marching cubes...")
     _t = time.time()
+    blurred_vol = skimage.filters.gaussian(volume.astype(np.float32), sigma=sigma)
     verts, faces, normals, _ = measure.marching_cubes(
-        volume.astype(np.float32),
-        level=0.5,
+        blurred_vol,
+        level=mc_level,
         spacing=(voxel_size, voxel_size, voxel_size)
     )
     logger.info(f"Computing marching cubes... Done in {time.time() - _t:.2f}s")
@@ -969,19 +974,14 @@ def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0):
 
     logger.info("Building Open3D PointCloud and Mesh...")
     _t = time.time()
-    # Build the Open3D point cloud
     pcd = o3d.geometry.PointCloud()
     pcd.points = o3d.utility.Vector3dVector(verts)
     pcd.normals = o3d.utility.Vector3dVector(normals)
     pcd.normalize_normals()
 
-    # Create empty triangle mesh object
     mesh = o3d.geometry.TriangleMesh()
-    # Assign vertex coordinates using Open3D's Vector3dVector format
     mesh.vertices = o3d.utility.Vector3dVector(verts)
-    # Assign triangle face indices using Open3D's Vector3iVector format
     mesh.triangles = o3d.utility.Vector3iVector(faces)
-    # Assign vertex normals
     mesh.vertex_normals = o3d.utility.Vector3dVector(normals)
     logger.info(f"Building Open3D PointCloud and Mesh... Done in {time.time() - _t:.2f}s")
     return pcd, mesh

--- a/plant3dvision/proc3d.py
+++ b/plant3dvision/proc3d.py
@@ -14,9 +14,11 @@ import networkx as nx
 import numpy as np
 import open3d as o3d
 import skimage
-from scipy.ndimage import binary_erosion, generate_binary_structure
+from scipy.ndimage import binary_erosion
+from scipy.ndimage import generate_binary_structure
 from scipy.ndimage.filters import gaussian_filter
-from scipy.ndimage.morphology import distance_transform_edt, binary_dilation
+from scipy.ndimage.morphology import binary_dilation
+from scipy.ndimage.morphology import distance_transform_edt
 from scipy.spatial import cKDTree
 from skimage import measure
 from skimage.exposure import rescale_intensity
@@ -32,49 +34,64 @@ except:
     logger.warning("Could not load CGAL bindings, some methods will be unavailable")
 
 
-def index2point(indexes, origin, voxel_size):
-    """Converts discrete nd indexes to a 3d points.
+def index2point(indexes: np.ndarray, origin: np.ndarray | list, voxel_size: float) -> np.ndarray:
+    """
+    Convert discrete voxel indices to world coordinates.
+
+    This function transforms integer voxel indices into physical 3‑D points by scaling each index with the
+    voxel size and translating by an origin offset.
 
     Parameters
     ----------
     indexes : numpy.ndarray
-        Nxd array of indices
-    origin : numpy.ndarray
-        1d array of length d
+        An ``(N, d)`` array of integer indices for each voxel.
+        ``N`` is the number of points and ``d`` is the dimensionality (typically 3).
+    origin : numpy.ndarray | list
+        A 1‑D array or list of length ``d`` that specifies the world coordinate of the
+        voxel at index ``(0, 0, ..., 0)``.
     voxel_size : float
-        size of voxels
+        The physical size of a voxel edge. All dimensions are assumed to be isotropic.
 
     Returns
     -------
     numpy.ndarray
-        Nxd array of points
+        An ``(N, d)`` array of world coordinates corresponding to ``indexes``.
+        The returned dtype is the result of broadcasting ``indexes`` and ``voxel_size`` (normally ``float``).
+
     """
     # Convert origin to numpy array if it's a list
     origin = np.asarray(origin)
     return voxel_size * indexes + origin[np.newaxis, :]
 
 
-def point2index(points, origin, voxel_size):
-    """Converts discrete nd indexes to a 3d points.
+def point2index(points: np.ndarray, origin: np.ndarray | list, voxel_size: float) -> np.ndarray:
+    """"
+    Convert continuous 3‑D points to discrete voxel indices.
+
+    This routine translates an array of points expressed in world coordinates into integer voxel indices
+    based on a specified origin and voxel size.
 
     Parameters
     ----------
     points : numpy.ndarray
-        Nxd array of points
-    origin : numpy.ndarray
-        1d array of length d
+        An ``(N, d)`` array of point coordinates.
+        ``N`` is the number of points and ``d`` is the dimensionality of the space.
+    origin : numpy.ndarray | list
+        A 1‑D array or list of length ``d`` representing the world coordinate of the voxel grid origin.
+        It is broadcast against ``points`` so each point is shifted relative to this origin.
     voxel_size : float
-        size of voxels
+        The physical size of a voxel edge (assumed equal along all dimensions).
 
     Returns
     -------
-    numpy.ndarray (dtype=int)
-        Nxd array of indices
+    numpy.ndarray
+        An ``(N, d)`` array of integer voxel indices.
+        Each index corresponds to the voxel that contains the input point.
     """
     return np.array(np.round((points - origin[np.newaxis, :]) / voxel_size), dtype=int)
 
 
-def pcd2mesh(pcd):
+def pcd2mesh(pcd: o3d.geometry.PointCloud) -> o3d.geometry.TriangleMesh:
     """Use CGAL to create a Delaunay triangulation of a point cloud with normals.
 
     Parameters
@@ -764,25 +781,43 @@ def vol2pcd_parallel(volume, origin, voxel_size, level_set_value=0):
     return pcd
 
 
-def vol2pcd(volume, origin, voxel_size, level_set_value=0):
-    """Converts a volume into a point-cloud with normals.
+def vol2pcd(volume: np.ndarray, origin: np.ndarray | list, voxel_size: float,
+            level_set_value: float = 0.) -> o3d.geometry.PointCloud:
+    """Convert a binary volumetric mask into an Open3D point cloud with normals.
+
+    This routine performs a distance transform on a 3‑D binary mask, extracts a level‑set surface around
+    the foreground–background boundary, computes smoothed surface normals, and returns a pointcloud
+    containing the sampled points in real‑world coordinates.
 
     Parameters
     ----------
     volume : numpy.ndarray
-        ``NxMxP`` 3D binary numpy array
-    origin : numpy.ndarray
-        Origin of the volume
+        3‑D binary array of shape ``(N, M, P)``. The foreground voxels (``1``) represent the object to be reconstructed.
+    origin : numpy.ndarray | list
+        3‑tuple or list giving the world coordinates of the array origin (the voxel at index ``[0, 0, 0]``).
     voxel_size : float
-        Voxel size to use to create the point-cloud from the array.
+        Physical size of a voxel edge in the same units as ``origin``.
     level_set_value : float, optional
-        distance of the level set on which the points are sampled
-        Defaults to ``0``.
+        Signed distance value at which the surface is extracted.
+        Positive values sample points inside the object, negative values sample points outside.
+        Default is ``0`` (the zero level set).
 
     Returns
     -------
     open3d.geometry.PointCloud
-        Point-cloud with normal vectors.
+        A point cloud whose points are positioned on the extracted level set and whose normals
+        point inwards (towards the foreground).
+
+    Notes
+    -----
+    The algorithm follows these steps:
+
+    1. Compute a signed distance field from the binary volume.
+    2. Smooth the gradients of the field with a Gaussian filter.
+    3. Locate voxels within a thin band around the chosen level set.
+    4. Compute point positions and normals from the gradients.
+    5. Convert voxel indices to world coordinates using ``origin`` and
+       ``voxel_size``.
 
     Examples
     --------
@@ -889,12 +924,15 @@ def vol2pcd(volume, origin, voxel_size, level_set_value=0):
     logger.info(f"Total execution time: {time.time() - start_time:.2f}s")
     return pcd
 
-def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0, sigma=0.5, mc_level=0.5):
+
+def vol2pcd_mc(volume: np.ndarray, origin: list[float, float, float], voxel_size: float,
+               level_set_value: float = 0., sigma: float = 0.5, mc_level: float = 0.5) -> tuple[
+    o3d.geometry.PointCloud, o3d.geometry.TriangleMesh]:
     """
     Generate a point cloud and triangle mesh from a binary volume using marching cubes.
 
     This function converts a 3D binary volume into a point cloud and a triangle mesh
-    by applying the marching cubes algorithm. The resulting point cloud and mesh
+    by applying the marching cubes' algorithm. The resulting point cloud and mesh
     are in world coordinates, accounting for voxel size and origin. Optionally, a
     level set value can be applied to dilate the input volume before processing.
 
@@ -902,7 +940,7 @@ def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0, sigma=0.5, mc_leve
     ----------
     volume : numpy.ndarray
         A 3D binary volume array representing the input data.
-    origin : Sequence[float]
+    origin : list of float
         The origin of the volume in world coordinates as (x, y, z).
     voxel_size : float
         The size of a voxel in world units.
@@ -912,20 +950,22 @@ def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0, sigma=0.5, mc_leve
     sigma : float, optional
         Standart deviation for the gaussian filtering prior to marching cubes.
     mc_level : float, optional
-        Level set for the marching cubes algorithm which sets at which level the surface is. Should be between 0 and 1.
+        Level set for the marching cubes algorithm which sets at which level the surface is.
+        Should be between 0 and 1.
 
     Returns
     -------
-    tuple
-        A tuple containing:
-        - pcd (open3d.geometry.PointCloud): The generated point cloud object.
-        - mesh (open3d.geometry.TriangleMesh): The generated triangle mesh object.
+    open3d.geometry.PointCloud
+        The generated point cloud object.
+    open3d.geometry.TriangleMesh
+        The generated triangle mesh object.
 
     Raises
     ------
     ValueError
         If any of the input parameters are invalid or the processing fails.
-        Examples
+
+    Examples
     --------
     >>> from plant3dvision.proc3d import vol2pcd_mc
     >>> from plantdb.commons.io import read_volume
@@ -947,6 +987,10 @@ def vol2pcd_mc(volume, origin, voxel_size, level_set_value=0, sigma=0.5, mc_leve
     >>> o3d.visualization.draw_geometries([pcd])
     >>> db.disconnect()
     """
+    # Convert boolean volume to uint8 to be able to perfrom operation (subtractions, ...)
+    if volume.dtype == np.bool:
+        volume = volume.astype(np.uint8)
+
     volume = (volume - np.min(volume)) / np.max(volume - np.min(volume))
     if level_set_value != 0:
         logger.info("Computing level set dilation...")
@@ -1392,17 +1436,41 @@ def pcd_convex_hull_volume(pcd):
 
 def chamfer_distance(pc1: np.ndarray | o3d.geometry.PointCloud, pc2: np.ndarray | o3d.geometry.PointCloud) -> float:
     """ Compute the symmetric Chamfer distance between two point clouds.
+
     Parameters
     ----------
     pc1, pc2 : np.ndarray or o3d.geometry.PointCloud
-        Point clouds of shape (N, D) and (M, D) respectively.
-        D is the dimensionality (3 for typical 3?D clouds).
+        Point clouds of shape ``(N, D)`` and ``(M, D)`` respectively.
+        ``D`` is the dimensionality (3 for typical 3-D clouds).
 
     Returns
     -------
     float
-        Mean of the squared nearest?neighbor distances from pc1?pc2
-        plus the mean from pc2?pc1.
+        Mean of the squared nearest-neighbor distances from `pc1` to `pc2`
+        plus the mean from `pc2` to `pc1`.
+
+    Examples
+    --------
+    >>> from plant3dvision.proc3d import chamfer_distance
+    >>> from plant3dvision.proc3d import vol2pcd
+    >>> from plant3dvision.proc3d import vol2pcd_mc
+    >>> from plantdb.commons.io import read_volume
+    >>> from plantdb.server.core.utils import compute_fileset_matches
+    >>> from plantdb.commons.test_database import test_database
+    >>> db = test_database()
+    >>> db.connect()
+    >>> db.login('admin', 'admin')
+    >>> scan = db.get_scan("real_plant_analyzed")
+    >>> vol_fs_id = compute_fileset_matches(scan)["Voxels"]
+    >>> vol_fs = scan.get_fileset(vol_fs_id)
+    >>> vol = read_volume(vol_fs.get_file("Voxels"))
+    >>> print(vol.shape)
+    (301, 301, 561)
+    >>> pcd = vol2pcd(vol>0., [0., 0., 0.], 0.5, level_set_value=0.0)
+    >>> pcd_mc, _ = vol2pcd_mc(vol>0., [0., 0., 0.], 0.5, level_set_value=0.0, sigma=0.8, mc_level=0.2)
+    >>> dist = chamfer_distance(pcd, pcd_mc)
+    >>> print(dist)
+    >>> db.disconnect()
     """
     # Convert open3d PointCloud to numpy arrays
     pc1 = np.asarray(pc1.points) if isinstance(pc1, o3d.geometry.PointCloud) else pc1

--- a/plant3dvision/tasks/proc2d.py
+++ b/plant3dvision/tasks/proc2d.py
@@ -335,7 +335,7 @@ class Masks(ParallelFileTask):
     """
     upstream_task = luigi.TaskParameter(default=Undistort)  # override default attribute from ``RomiTask``
     type = luigi.Parameter("linear")
-    colorspace = luigi.ChoiceParameter("RGB", choices=["RGB", "HSV", "YCbCr"])
+    colorspace = luigi.ChoiceParameter(default="RGB", choices=["RGB", "HSV", "YCbCr"], var_type=str)
     parameters = luigi.ListParameter(default=[0, 1, 0])
     min_threshold = luigi.FloatParameter(default=0.0)
     max_threshold = luigi.FloatParameter(default=0.4)

--- a/plant3dvision/tasks/proc3d.py
+++ b/plant3dvision/tasks/proc3d.py
@@ -32,8 +32,16 @@ class PointCloud(RomiTask):
     ----------
     upstream_task : luigi.TaskParameter, optional
         The upstream task providing the input data for this task. Defaults to ``Voxels``.
+    algorithm : luigi.ChoiceParameter, optional
+        The algorithm to use to comput the pointcloud.
+        Use 'marching-cubes' for a fast processing with a control over smoothing operation.
+        Use 'distance-transform' to extract a level‑set surface around the foreground–background boundary.
+        Default to ``'marching-cubes'``.
     level_set_value : luigi.FloatParameter, optional
-        Value used to define the level set for point cloud generation. Default is ``1.0``.
+        Value used to define the level set for point cloud generation.
+        With the ``'marching-cubes'`` `algorithm` we advise to use `0.`.
+        With the ``'distance-transform'`` `algorithm` we advise to use `1.`.
+        Default is ``0.0``.
     missing_images_threshold : luigi.IntParameter, optional
         Threshold for the number of missing images allowed in the reconstructed volume.
     labels : luigi.ListParameters, optional
@@ -48,6 +56,12 @@ class PointCloud(RomiTask):
         Defaults to ``10.0``.
     min_score : luigi.FloatParameter, optional
         Minimum score threshold for class predictions in a multi-class volume.
+        Defaults to ``0.2``.
+    sigma : luigi.FloatParameter, optional
+        Standard deviation for Gaussian kernel (only for marching-cubes).
+        Defaults to ``0.2``.
+    mc_level : luigi.FloatParameter, optional
+        Level set value for the marching cubes algorithm. Should be between 0 and 1.
         Defaults to ``0.2``.
 
     Returns
@@ -76,7 +90,10 @@ class PointCloud(RomiTask):
     If multi-class, point label information is included in the metadata.
     """
     upstream_task = luigi.TaskParameter(default=Voxels)  # override default attribute from ``RomiTask``
-    level_set_value = luigi.FloatParameter(default=1.0)
+    algorithm = luigi.ChoiceParameter(
+        default='marching-cubes', choices=['distance-transform', 'marching-cubes'], var_type=str
+    )
+    level_set_value = luigi.FloatParameter(default=0.0)
 
     missing_images_threshold = luigi.IntParameter(default=2)
 
@@ -84,12 +101,11 @@ class PointCloud(RomiTask):
     background_prior = luigi.FloatParameter(default=1.0)  # only used if labels were defined (multiclass)
     min_contrast = luigi.FloatParameter(default=10.0)  # only used if labels were defined (multiclass)
     min_score = luigi.FloatParameter(default=0.2)  # only used if labels were defined (multiclass)
-    algorithm = luigi.ChoiceParameter(
-        default='marching-cubes', choices=['distance-transform', 'marching-cubes'], var_type=str
-    )
 
-    sigma = luigi.FloatParameter(default=0.8, description="Standard deviation for Gaussian kernel (only for marching-cubes)")
-    mc_level = luigi.FloatParameter(default=0.5, description="Level set value for the marching cubes algorithm. Should be between 0 and 1")
+    sigma = luigi.FloatParameter(default=0.8,
+                                 description="Standard deviation for Gaussian kernel (only for marching-cubes)")
+    mc_level = luigi.FloatParameter(default=0.5,
+                                    description="Level set value for the marching cubes algorithm. Should be between 0 and 1")
 
     def run_multiclass(self, labels):
         """Processes multi-class voxel data to generate a unified point cloud.

--- a/plant3dvision/tasks/proc3d.py
+++ b/plant3dvision/tasks/proc3d.py
@@ -33,7 +33,7 @@ class PointCloud(RomiTask):
     upstream_task : luigi.TaskParameter, optional
         The upstream task providing the input data for this task. Defaults to ``Voxels``.
     algorithm : luigi.ChoiceParameter, optional
-        The algorithm to use to comput the pointcloud.
+        The algorithm to use to compute the pointcloud.
         Use 'marching-cubes' for a fast processing with a control over smoothing operation.
         Use 'distance-transform' to extract a level‑set surface around the foreground–background boundary.
         Default to ``'marching-cubes'``.
@@ -59,10 +59,10 @@ class PointCloud(RomiTask):
         Defaults to ``0.2``.
     sigma : luigi.FloatParameter, optional
         Standard deviation for Gaussian kernel (only for marching-cubes).
-        Defaults to ``0.2``.
+        Defaults to ``0.8``.
     mc_level : luigi.FloatParameter, optional
         Level set value for the marching cubes algorithm. Should be between 0 and 1.
-        Defaults to ``0.2``.
+        Defaults to ``0.5``.
 
     Returns
     -------

--- a/plant3dvision/tasks/proc3d.py
+++ b/plant3dvision/tasks/proc3d.py
@@ -84,6 +84,12 @@ class PointCloud(RomiTask):
     background_prior = luigi.FloatParameter(default=1.0)  # only used if labels were defined (multiclass)
     min_contrast = luigi.FloatParameter(default=10.0)  # only used if labels were defined (multiclass)
     min_score = luigi.FloatParameter(default=0.2)  # only used if labels were defined (multiclass)
+    algorithm = luigi.ChoiceParameter(
+        default='marching-cubes', choices=['distance-transform', 'marching-cubes'], var_type=str
+    )
+
+    sigma = luigi.FloatParameter(default=0.8, description="Standard deviation for Gaussian kernel (only for marching-cubes)")
+    mc_level = luigi.FloatParameter(default=0.5, description="Level set value for the marching cubes algorithm. Should be between 0 and 1")
 
     def run_multiclass(self, labels):
         """Processes multi-class voxel data to generate a unified point cloud.
@@ -162,7 +168,10 @@ class PointCloud(RomiTask):
                 # Apply minimum score threshold
                 pred_c *= (pred_c > self.min_score)
                 # Convert filtered volume to a partial point cloud
-                out = proc3d.vol2pcd(pred_c, origin, voxel_size, self.level_set_value)
+                if self.algorithm == 'marching-cubes':
+                    out, _ = proc3d.vol2pcd_mc(pred_c, origin, voxel_size, self.level_set_value, self.sigma, self.mc_level)
+                else:
+                    out = proc3d.vol2pcd(pred_c, origin, voxel_size, self.level_set_value)
                 # Assign a color to all points in this partial cloud
                 color = np.zeros((len(out.points), 3))
                 if label[i] in colors:
@@ -204,7 +213,10 @@ class PointCloud(RomiTask):
         # Binarize the volume
         voxels = self._binarize(voxels, method, n_img - self.missing_images_threshold)
         # Directly create a point cloud from the single volume
-        out = proc3d.vol2pcd(voxels, origin, voxel_size, self.level_set_value)
+        if self.algorithm == 'marching-cubes':
+            out, _ = proc3d.vol2pcd_mc(voxels, origin, voxel_size, self.level_set_value, self.sigma, self.mc_level)
+        else:
+            out = proc3d.vol2pcd(voxels, origin, voxel_size, self.level_set_value)
         # Write the point cloud to file and attach metadata
         io.write_point_cloud(self.output_file(create=True), out)
         self.output_file().set_metadata({'voxel_size': voxel_size})


### PR DESCRIPTION
## Summary
This Pull Request introduces a new algorithm (marching-cubes) for point cloud generation, adds relevant configuration parameters, and updates the codebase to integrate this functionality. It involves changes to configuration files, processing logic, and new helper functions for improved 3D data handling.

## Main changes:

### Configuration Updates

- Added `algorithm`, `sigma`, and `mc_level` parameters in TOML configuration files to support the marching-cubes algorithm.
- Adjusted default values for `level_set_value` depending on the algorithm.

### Code Enhancements

- Introduced a new `vol2pcd_mc` function to implement point cloud and mesh generation using the marching cubes algorithm.
- Added support for choosing between `'distance-transform'` and `'marching-cubes'` in 3D data processing tasks (`proc3d.py` and associated Luigi tasks files).
- Added Chamfer distance calculation as a utility for comparing point clouds.
- Improved type annotations, error handling, and parameter documentation for existing and new functions.

### Minor Updates

- Fixed issues in existing documentation and enhanced docstring consistency.
- Updated module imports and added new dependencies for image processing tasks.