### PR TITLE
Add CropWithBoundingBox task and crop_image helper

### DIFF
--- a/plant3dvision/proc2d.py
+++ b/plant3dvision/proc2d.py
@@ -20,6 +20,63 @@ from skimage.color import convert_colorspace
 EPS = 1e-9
 
 
+def crop_image(img: np.ndarray, bbox: list[int]) -> np.ndarray:
+    """Crop a 2‑D image according to a bounding box.
+
+    Parameters
+    ----------
+    img : np.ndarray
+        An image as a NumPy array (H, W, C) or (H, W) for grayscale.
+    bbox : list[int]
+        Bounding box described as ``[x, y, w, h]`` where ``x`` and ``y`` are the
+        top‑left corner coordinates. ``w`` and ``h`` are the width and height.
+        If ``w`` or ``h`` are ``-1`` the function uses the remaining image size
+        in that direction (i.e. crops to the image border).
+
+    Returns
+    -------
+    np.ndarray
+        The cropped region of the original image.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> import matplotlib.pyplot as plt
+    >>> from imageio.v3 import imread
+    >>> from plant3dvision import test_db_path
+    >>> from plant3dvision.proc2d import crop_image
+    >>> path = test_db_path()
+    >>> img = imread(path.joinpath('real_plant/images/00000_rgb.jpg'))
+    >>> cropped = crop_image(img, bbox=[180, 0, 1080, -1])
+    >>> plt.imshow(cropped)
+    >>> plt.title("Cropped image")
+    >>> plt.axis('off')
+    >>> plt.tight_layout()
+    >>> plt.show()
+    """
+    # Unpack bounding box
+    x, y, w, h = bbox
+
+    # Image dimensions
+    img_h, img_w = img.shape[:2]
+
+    # Resolve ``-1`` placeholders (full remaining size)
+    if w == -1:
+        w = img_w - x
+    if h == -1:
+        h = img_h - y
+
+    # Clamp coordinates to ensure they stay inside the image
+    x = max(0, min(x, img_w))
+    y = max(0, min(y, img_h))
+    w = max(0, min(w, img_w - x))
+    h = max(0, min(h, img_h - y))
+
+    # Perform the actual crop
+    cropped = img[y : y + h, x : x + w]
+
+    return cropped
+
 def undistort(img, camera_mtx, distortion_vect):
     """Use OpenCV to undistort an image thanks to a camera model.
 

--- a/plant3dvision/tasks/proc2d.py
+++ b/plant3dvision/tasks/proc2d.py
@@ -13,6 +13,7 @@ import numpy as np
 import plantdb.commons.db
 from plant3dvision import proc2d
 from plant3dvision.camera import colmap_params_from_kwargs
+from plant3dvision.proc2d import crop_image
 from plant3dvision.tasks.colmap import Colmap
 from plant3dvision.utils import jsonify
 from plantdb.commons import io
@@ -24,6 +25,84 @@ from romitask.task import ParallelFileTask
 
 logger = get_logger(__name__, log_level="INFO")
 
+
+class CropWithBoundingBox(ParallelFileTask):
+    """Crop each 2D image cropping it to a given bounding box.
+
+    This task reads every input image, extracts a rectangular region defined by
+    ``bbox`` (x, y, width, height) and writes the cropped image to the output
+    fileset, preserving the original file identifier and metadata.
+
+    Parameters
+    ----------
+    upstream_task : luigi.TaskParameter, optional
+        The task providing the input images. Defaults to ``ImagesFilesetExists``.
+    scan_id : luigi.Parameter, optional
+        Dataset identifier (scan name) for the output fileset.
+    query : luigi.DictParameter, optional
+        Filtering dictionary applied to input ``Fileset`` metadata.
+    n_workers : luigi.IntParameter, optional
+        Number of worker threads for parallel processing. ``None`` uses the
+        default ``ThreadPoolExecutor`` behaviour.
+    parallel : luigi.BoolParameter, optional
+        Enable/disable parallel execution. Defaults to ``True``.
+    bbox : luigi.ListParameter, optional
+        List of four integers ``[x, y, w, h]`` defining the cropping rectangle.
+        ``x`` and ``y`` are the top‑left corner coordinates. ``w`` and ``h`` are the
+        width and height. If ``w`` or ``h`` are ``-1`` the full image size in that
+        direction is used. Default crops the whole image.
+
+    Returns
+    -------
+    romitask.task.FilesetTarget
+        Fileset containing the cropped copies of the input images.
+    """
+
+    upstream_task = luigi.TaskParameter(default=ImagesFilesetExists)
+    n_workers = luigi.IntParameter(default=None)
+    parallel = luigi.BoolParameter(default=True)
+    bbox = luigi.ListParameter(default=[180, 0, 1080, -1])  # x, y, width, height
+
+    def run(self):
+        """Delegate the processing to the parent ``ParallelFileTask``."""
+        # The parent class handles iteration over all input files.
+        super().run(self.input().get(), self.output().get())
+
+    def f(self, fi, outfs):
+        """Crop a single image according to ``bbox`` and copy it to the output.
+
+        Parameters
+        ----------
+        fi : plantdb.commons.db.File
+            Input image file.
+        outfs : plantdb.commons.db.Fileset
+            Output fileset where the cropped image will be stored.
+
+        Returns
+        -------
+        plantdb.commons.db.File
+            New file containing the cropped image.
+        """
+        # Load the image
+        img = io.read_image(fi)
+
+        # Perform cropping
+        cropped = crop_image(img, bbox=list(self.bbox))
+
+        # Save the cropped image preserving the original file id
+        outfi = outfs.create_file(fi.id)
+        io.write_image(outfi, cropped)
+
+        # Preserve original metadata and add task‑specific info
+        md = {
+            'upstream_task': str(self.upstream_task.get_task_family()),
+            'bbox': self.bbox,
+        }
+        if self.query != {}:
+            md.update({'query': jsonify(self.query)})
+        outfi.set_metadata({self.get_task_family(): md})
+
+        return outfi
 
 class Undistort(ParallelFileTask):
     """Image distortion correction using camera intrinsic parameters.


### PR DESCRIPTION
**Goal**
Enable cropping for the image dataset.

**Reason**
Images acquired with the Sony RX-0 (v1 and v2 PlantImager) present black margins, we would like to remove them before processing by Colmap.

**Added**
- `crop_image` helper in `plant3dvision/proc2d.py` that crops 2‑D NumPy images using a `[x, y, w, h]` bounding box, supports `-1` as a full‑size placeholder, clamps coordinates to image bounds, and preserves the original array type.
- `CropWithBoundingBox` task in `plant3dvision/tasks/proc2d.py`, a `ParallelFileTask` subclass that:
  - Accepts `upstream_task`, `n_workers`, `parallel`, and `bbox` (default `[180, 0, 1080, -1]`).
  - Reads each input image with `io.read_image`, crops it via `crop_image`, and writes the result while preserving the original file ID.
  - Copies original metadata and adds task‑specific metadata (`upstream_task`, `bbox`).