### PR TITLE
Remove .json extension from COLMAP output files

### DIFF
--- a/plant3dvision/colmap.py
+++ b/plant3dvision/colmap.py
@@ -521,7 +521,7 @@ class ColmapRunner(object):
     compute_dense : bool
         If ``True``, it will compute the dense point cloud.
     all_cli_args : dict
-        Dictionary of arguments to pass to colmap command lines.
+        Dictionary of arguments to pass to COLMAP CLI.
     align_pcd : bool
         If ``True``, it will align spare (& dense) point cloud(s) coordinate system of given camera centers.
     use_calibration : bool
@@ -606,7 +606,7 @@ class ColmapRunner(object):
         --------
         >>> from plant3dvision.colmap import ColmapRunner
         >>> from plantdb.commons.test_database import test_database
-        >>> db = test_database('real_plant')
+        >>> db = test_database('real_plant', no_auth=True)
         >>> db.connect()
         >>> # - Select the dataset to reconstruct:
         >>> dataset = db.get_scan("real_plant")
@@ -615,7 +615,8 @@ class ColmapRunner(object):
         >>> image_files = images_fileset.get_files()
 
         >>> args = {"feature_extractor": {"--ImageReader.single_camera": "1"}}
-        >>> colmap = ColmapRunner(image_files, matcher_method="spatial", align_pcd=True, all_cli_args=args, colmap_exe="roboticsmicrofarms/colmap:3.8")
+        >>> colmap = ColmapRunner(image_files, matcher_method="exhaustive", align_pcd=True, all_cli_args=args, colmap_exe="roboticsmicrofarms/colmap:3.8")
+        >>> print(colmap.colmap_workdir)
         >>> colmap.feature_extractor()  #1 - Extract features from images
         >>> colmap.matcher()  #2 - Match extracted features from images, requires `feature_extractor()`
         >>> colmap.mapper()  #3 - Sparse point cloud reconstruction, requires `matcher()`

--- a/plant3dvision/tasks/colmap.py
+++ b/plant3dvision/tasks/colmap.py
@@ -1108,9 +1108,9 @@ class Colmap(RomiTask):
             dist_json.update({
                 f"{dist_name}_distances": dist_values,
             })
-        dist_outfile = self.output_file(f"ref2pred_pose_distances", create=True)
+        dist_outfile = self.output_file("ref2pred_pose_distances", create=True)
         io.write_json(dist_outfile, dist_json)
-        dist_stats_outfile = self.output_file(f"ref2pred_pose_distances_stats", create=True)
+        dist_stats_outfile = self.output_file("ref2pred_pose_distances_stats", create=True)
         io.write_json(dist_stats_outfile, dist_stats_json)
 
         def _rename_retry_file(fpath):

--- a/plant3dvision/tasks/colmap.py
+++ b/plant3dvision/tasks/colmap.py
@@ -785,7 +785,7 @@ class Colmap(RomiTask):
     -----
     This task requires COLMAP to be installed or available as a container.
 
-    For exhaustive matching, all image pairs are compared which is suitable for datasets
+    For exhaustive matching, all image pairs are compared, which is suitable for datasets
     with up to several hundred images.
 
     For sequential matching, only consecutive frames are matched, which is suitable for
@@ -867,7 +867,7 @@ class Colmap(RomiTask):
             except:
                 pass
 
-        # An Error should not be raised as it force to know the point cloud geometry
+        # An Error should not be raised as it forces to know the point cloud geometry
         #  before even attempting its reconstruction.
         # if bounding_box is None:
         #     raise IOError(
@@ -895,7 +895,7 @@ class Colmap(RomiTask):
         self.cli_args["feature_extractor"]["--ImageReader.single_camera"] = str(self.single_camera)
 
     def set_camera_model(self):
-        """Configure COLMAP CLI parameters to defines camera model."""
+        """Configure COLMAP CLI parameters to defines a camera model."""
         if "feature_extractor" not in self.cli_args:
             self.cli_args["feature_extractor"] = {}
         # - Define the camera model:
@@ -1108,9 +1108,9 @@ class Colmap(RomiTask):
             dist_json.update({
                 f"{dist_name}_distances": dist_values,
             })
-        dist_outfile = self.output_file(f"ref2pred_pose_distances.json", create=True)
+        dist_outfile = self.output_file(f"ref2pred_pose_distances", create=True)
         io.write_json(dist_outfile, dist_json)
-        dist_stats_outfile = self.output_file(f"ref2pred_pose_distances_stats.json", create=True)
+        dist_stats_outfile = self.output_file(f"ref2pred_pose_distances_stats", create=True)
         io.write_json(dist_stats_outfile, dist_stats_json)
 
         def _rename_retry_file(fpath):


### PR DESCRIPTION
This PR removes the unnecessary `.json` extension from the COLMAP task output files `ref2pred_pose_distances` and `ref2pred_pose_distances_stats`, correcting the filenames and fixing related typos.