### PR TITLE
Rename `type` parameter to `method` in Proc2D task

### DIFF
--- a/plant3dvision/tasks/proc2d.py
+++ b/plant3dvision/tasks/proc2d.py
@@ -418,7 +418,7 @@ class Masks(ParallelFileTask):
 
     """
     upstream_task = luigi.TaskParameter(default=Undistort)  # override default attribute from ``RomiTask``
-    type = luigi.Parameter("linear")
+    method = luigi.Parameter("linear")
     colorspace = luigi.ChoiceParameter("RGB", choices=["RGB", "HSV", "YCbCr"])
     parameters = luigi.ListParameter(default=[0, 1, 0])
     min_threshold = luigi.FloatParameter(default=0.0)


### PR DESCRIPTION
**Summary**
- Updated the `Proc2D` Luigi task to replace the `type` parameter with `method`.
- This change prevents a name clash with Python's built‑in `type` and more accurately reflects the parameter’s purpose.

**Changes**
- Modified `plant3dvision/tasks/proc2d.py`:
  - `type = luigi.Parameter("linear")` → `method = luigi.Parameter("linear")`
  - Adjusted any references to the renamed parameter within the task.

**Impact**
- No functional changes; only a renaming for clarity and to avoid potential bugs.