### PR TITLE
Standardize upstream_task parameter description

### DIFF
--- a/plant3dvision/tasks/colmap.py
+++ b/plant3dvision/tasks/colmap.py
@@ -707,7 +707,7 @@ class Colmap(RomiTask):
     Parameters
     ----------
     upstream_task : luigi.TaskParameter, optional
-        Task upstream of this task. Defaults to ``ImagesFilesetExists``.
+        The upstream task. Defaults to ``ImagesFilesetExists``.
     scan_id : luigi.Parameter, optional
         The dataset ID (scan name) to use to create the ``FilesetTarget``.
         If unspecified (default), the current active scan will be used.

--- a/plant3dvision/tasks/proc2d.py
+++ b/plant3dvision/tasks/proc2d.py
@@ -36,7 +36,7 @@ class CropWithBoundingBox(ParallelFileTask):
     Parameters
     ----------
     upstream_task : luigi.TaskParameter, optional
-        The task providing the input images. Defaults to ``ImagesFilesetExists``.
+        The upstream task, should provide the input images. Defaults to ``ImagesFilesetExists``.
     scan_id : luigi.Parameter, optional
         Dataset identifier (scan name) for the output fileset.
     query : luigi.DictParameter, optional
@@ -114,8 +114,7 @@ class Undistort(ParallelFileTask):
     Parameters
     ----------
     upstream_task : luigi.TaskParameter, optional
-        The task to use upstream to the `Undistort` tasks.
-        It should be a tasks that generates a ``Fileset`` of RGB images.
+        The upstream task, should be a tasks that generates a ``Fileset`` of RGB images.
         Defaults to ``'ImagesFilesetExists'``.
     scan_id : luigi.Parameter, optional
         The dataset id (scan name) to use to create the ``FilesetTarget``.
@@ -338,8 +337,7 @@ class Masks(ParallelFileTask):
     Parameters
     ----------
     upstream_task : luigi.TaskParameter, optional
-        The task to use upstream to this task.
-        It should be a task that generates a ``Fileset`` of RGB images.
+        The upstream task, should be a task that generates a ``Fileset`` of RGB images.
         It can be ``ImagesFilesetExists`` or ``Undistort``.
         Defaults to `'Undistort'`.
     scan_id : luigi.Parameter, optional
@@ -518,8 +516,7 @@ class Segmentation2D(FileByFileTask):
     Attributes
     ----------
     upstream_task : luigi.TaskParameter, optional
-        The task to use upstream to this task.
-        It should be a task that generates a ``Fileset`` of RGB images.
+        The upstream task, should be a task that generates a ``Fileset`` of RGB images.
         It can thus be ``ImagesFilesetExists`` or ``Undistort``.
         Defaults to `'Undistort'`.
     scan_id : luigi.Parameter, optional

--- a/plant3dvision/tasks/proc3d.py
+++ b/plant3dvision/tasks/proc3d.py
@@ -282,14 +282,14 @@ class SegmentedPointCloud(RomiTask):
     Attributes
     ----------
     upstream_task : luigi.TaskParameter, optional
-        Task upstream of this task, should provide a point cloud.
+        The upstream task, should provide a point cloud.
         Should be either ``Colmap`` or ``PointCloud``.
         Defaults to ``Colmap``.
     scan_id : luigi.Parameter, optional
         The dataset id (scan name) to use to create the ``FilesetTarget``.
         If unspecified (default), the current active scan will be used.
     upstream_segmentation : luigi.TaskParameter, optional
-        Task upstream of this task, should provide a 2D segmentation of the 'images'.
+        The upstream task, should provide a 2D segmentation of the 'images'.
         Defaults to ``Segmentation2D``.
     use_colmap_poses : luigi.BoolParameter, optional
         Defaults to ``True``.
@@ -472,7 +472,7 @@ class TriangleMesh(RomiTask):
     Parameters
     ----------
     upstream_task  : luigi.TaskParameter, optional
-        Task upstream of this task, should provide a point cloud.
+        The upstream task, should provide a point cloud.
         Defaults to ``PointCloud``.
     scan_id : luigi.Parameter, optional
         The dataset id (scan name) to use to create the ``FilesetTarget``.
@@ -576,7 +576,7 @@ class ClusteredMesh(RomiTask):
     Attributes
     ----------
     upstream_task : luigi.TaskParameter, optional
-        The task upstream to this one, should provide a segmented point cloud.
+        The upstream task, should provide a segmented point cloud.
         Defaults to ``SegmentedPointCloud``.
     scan_id : luigi.Parameter, optional
         The dataset id (scan name) to use to create the ``FilesetTarget``.
@@ -661,7 +661,7 @@ class FilteredSegmentedPointCloud(RomiTask):
     Attributes
     ----------
     upstream_task : luigi.TaskParameter, optional
-        Task upstream of this task, should provide a **labelled** point cloud.
+        The upstream task, should provide a **labelled** point cloud.
         Defaults to ``SegmentedPointCloud``.
     scan_id : luigi.Parameter, optional
         The dataset id (scan name) to use to create the ``FilesetTarget``.
@@ -714,7 +714,7 @@ class OrganSegmentation(RomiTask):
     Attributes
     ----------
     upstream_task : luigi.TaskParameter, optional
-        The task upstream to this one, should provide a segmented point cloud.
+        The upstream task, should provide a segmented point cloud.
         Defaults to ``SegmentedPointCloud``.
     scan_id : luigi.Parameter, optional
         The dataset id (scan name) to use to create the ``FilesetTarget``.
@@ -837,7 +837,7 @@ class CurveSkeleton(RomiTask):
     Parameters
     ----------
     upstream_task : luigi.TaskParameter
-        The task upstream to this one, should provide a triangular mesh.
+        The upstream task, should provide a triangular mesh.
         Defaults to ``TriangleMesh``.
     scan_id : luigi.Parameter, optional
         The dataset id (scan name) to use to create the ``FilesetTarget``.
@@ -905,7 +905,7 @@ class RefineSkeleton(RomiTask):
     Parameters
     ----------
     upstream_task : luigi.TaskParameter
-        The task upstream to this one, should provide a triangular mesh.
+        The upstream task, should provide a triangular mesh.
         Defaults to ``CurveSkeleton``.
     upstream_pcd : luigi.TaskParameter
         The task providing the point cloud to refine the skeleton from.
@@ -1015,7 +1015,7 @@ class VoxelsWithPrior(RomiTask):
     Attributes
     ----------
     upstream_task : luigi.TaskParameter, optional
-        The task upstream to this one, should provide an NPZ voxel volume.
+        The upstream task, should provide an NPZ voxel volume.
         Defaults to ``Voxels``.
     scan_id : luigi.Parameter, optional
         The dataset id (scan name) to use to create the ``FilesetTarget``.


### PR DESCRIPTION
### Summary
Refined the docstring for the `upstream_task` parameter across several task modules to improve clarity and maintain consistent wording.

### Changes Made
- **`plant3dvision/tasks/colmap.py`**
  - Updated description from “Task upstream of this task.” to **“The upstream task.”**
- **`plant3dvision/tasks/proc3d.py`**
  - Revised all `upstream_task` docstrings to **“The upstream task, should …”**
- **`plant3dvision/tasks/proc2d.py`**
  - Applied the same phrasing (**“The upstream task, should be …”**) uniformly to image source task definitions.

These updates make the documentation more concise and consistent throughout the codebase.