### PR TITLE
Enable hierarchy awareness for Clean task

### DIFF
--- a/configs/fast_geom_pipe_real.toml
+++ b/configs/fast_geom_pipe_real.toml
@@ -1,6 +1,6 @@
 [Undistort]
 upstream_task = "ImagesFilesetExists"
-camera_model_src = "ExtrinsicCalibration"
+upstream_camera_model = "ExtrinsicCalibration"
 camera_model = ""
 intrinsic_calib_scan_id = ""
 extrinsic_calib_scan_id = "extrinsic_calib_1"  # use a dataset with calibrated intrinsic camera params

--- a/configs/geom_pipe_full.toml
+++ b/configs/geom_pipe_full.toml
@@ -93,7 +93,7 @@ parallel = true  # Default: true
 n_workers = -1  # Default: -1 (Default ``concurrent.futures.ThreadPoolExecutor`` behavior)
 # Source of the camera model
 # Options: 'Colmap', 'IntrinsicCalibration', 'ExtrinsicCalibration'
-camera_model_src = "Colmap"  # Default: "Colmap"
+upstream_camera_model = "Colmap"  # Default: "Colmap"
 # Camera model to use if using IntrinsicCalibration
 # Options: "SIMPLE_RADIAL", "RADIAL", "OPENCV"
 camera_model = "SIMPLE_RADIAL"  # Default: "SIMPLE_RADIAL"

--- a/configs/ml_pipe_full.toml
+++ b/configs/ml_pipe_full.toml
@@ -96,7 +96,7 @@ parallel = true  # Default: true
 n_workers = -1  # Default: -1 (Default ``concurrent.futures.ThreadPoolExecutor`` behavior)
 # Source of the camera model
 # Options: 'Colmap', 'IntrinsicCalibration', 'ExtrinsicCalibration'
-camera_model_src = "Colmap"  # Default: "Colmap"
+upstream_camera_model = "Colmap"  # Default: "Colmap"
 # Camera model to use if using IntrinsicCalibration
 # Options: "SIMPLE_RADIAL", "RADIAL", "OPENCV"
 camera_model = "SIMPLE_RADIAL"  # Default: "SIMPLE_RADIAL"

--- a/plant3dvision/cli/create_charuco_board.py
+++ b/plant3dvision/cli/create_charuco_board.py
@@ -46,7 +46,7 @@ from typing import Any
 
 import click
 import cv2
-import toml
+import tomlkit
 
 from plant3dvision.calibration import get_charuco_board
 
@@ -83,7 +83,7 @@ def load_charuco_board_config_from_toml(config: str | Path) -> CharucoBoardConfi
     toml.TomlDecodeError
         If the file contents cannot be parsed as valid TOML.
     """
-    cfg: dict[str, Any] = toml.load(config)
+    cfg: dict[str, Any] = tomlkit.load(config)
 
     n_squares_x = int(cfg["CreateCharucoBoard"]["n_squares_x"])
     n_squares_y = int(cfg["CreateCharucoBoard"]["n_squares_y"])

--- a/plant3dvision/cli/robustness_evaluation.py
+++ b/plant3dvision/cli/robustness_evaluation.py
@@ -12,7 +12,7 @@ import sys
 import tempfile
 from pathlib import Path
 
-import toml
+import tomlkit
 from tqdm import tqdm
 
 from plant3dvision.compare import *
@@ -317,7 +317,7 @@ def _run_clean_if_requested(tmp_scan_dir, clean):
         # Create a quiet Clean task configuration:
         with open(bak_cfg_file, 'w') as cfg_f:
             cfg = {"Clean": {"no_confirm": True}}
-            toml.dump(cfg, cfg_f)
+            tomlkit.dump(cfg, cfg_f)
         romi_run_task(tmp_scan_dir, "Clean", str(bak_cfg_file))
     else:
         logger.info("No cleaning of the reference scan dataset!")
@@ -535,7 +535,7 @@ def check_extra_dataset(db_location, config_file):
     list
         The list of extra dataset required to run the robustness evaluation with this pipeline configuration.
     """
-    pipeline_cfg = toml.load(open(config_file, 'r'))
+    pipeline_cfg = tomlkit.load(open(config_file, 'r'))
     extra_ds = []
     for section, cfg_dict in pipeline_cfg.items():
         for k, v in cfg_dict.items():

--- a/plant3dvision/gui/colmap_poses.py
+++ b/plant3dvision/gui/colmap_poses.py
@@ -11,7 +11,7 @@ import sys
 from os.path import join
 from pathlib import Path
 
-import toml
+import tomlkit
 
 from plant3dvision.camera import format_camera_params
 from plant3dvision.tasks.colmap import compute_colmap_poses_from_images_json
@@ -68,7 +68,7 @@ def main(dataset_path):
         cameras = json.load(camera_json)
 
     # - Get some hardware metadata:
-    scan_cfg = toml.load(join(current_scan.path(), SCAN_TOML))
+    scan_cfg = tomlkit.load(join(current_scan.path(), SCAN_TOML))
     hardware = scan_cfg['Scan']['metadata']['hardware']
     hardware_str = f"sensor: {hardware.get('sensor', None)}\n"
 

--- a/plant3dvision/gui/reconstruction_explorer.py
+++ b/plant3dvision/gui/reconstruction_explorer.py
@@ -1,6 +1,6 @@
 import os
 
-import toml
+import tomlkit
 from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import QDoubleSpinBox
 from PySide6.QtWidgets import QSpinBox
@@ -555,7 +555,7 @@ class ReconstructionExplorer(QMainWindow):
         self._spacing = None
 
         # Load the reconstruction pipeline configuration
-        self._pipeline_cfg = toml.load(scan.path() / "pipeline.toml")
+        self._pipeline_cfg = tomlkit.load(scan.path() / "pipeline.toml")
 
         # Setup slider
         n = len(self._image_files)

--- a/plant3dvision/tasks/calibration.py
+++ b/plant3dvision/tasks/calibration.py
@@ -453,7 +453,7 @@ class ExtrinsicCalibration(RomiTask):
         self.cli_args["mapper"]["--Mapper.ba_refine_extra_params"] = "0"
 
     def run(self):
-        import toml
+        import tomlkit
         from os.path import abspath
         from os.path import join
         from plant3dvision.filenames import COLMAP_CAMERAS_ID
@@ -476,7 +476,7 @@ class ExtrinsicCalibration(RomiTask):
         images_fileset = self.input().get()
         # Get the scan configuration used to acquire the dataset (with CalibrationScan task):
         scan_cfg = abspath(join(images_fileset.path(), '..', "scan.toml"))
-        scan_cfg = toml.load(scan_cfg)
+        scan_cfg = tomlkit.load(scan_cfg)
 
         # - Get CNC images pose from metadata:
         cnc_poses = get_cnc_poses_from_images_metadata(images_fileset.scan)

--- a/plant3dvision/tasks/colmap.py
+++ b/plant3dvision/tasks/colmap.py
@@ -17,7 +17,7 @@ from typing import get_args
 import luigi
 import numpy as np
 import pandas as pd
-import toml
+import tomlkit
 from matplotlib.lines import Line2D
 from scipy.spatial.distance import euclidean
 
@@ -564,7 +564,7 @@ def get_scan_config(scan_path: str | Path) -> dict:
     if os.path.isfile(path):
         try:
             with open(path, "r") as f:
-                scan_config = toml.load(f)
+                scan_config = tomlkit.load(f)
         except toml.TomlDecodeError:
             logger.error(f"Could not load scan config from '{path}'!")
             raise
@@ -608,7 +608,7 @@ def check_scan_parameters(scan_to_calibrate: Scan, calibration_scan: Scan) -> bo
     >>> db.disconnect()
 
     """
-    import toml
+    import tomlkit
     # Load acquisition config file for calibration scan:
     calib_scan_cfg = get_scan_config(calibration_scan.path())
     # Load acquisition config file for scan to calibrate:
@@ -663,10 +663,10 @@ def check_colmap_cfg(current_cfg: dict[str, Any], current_scan: Scan, calibratio
     calibration_scan : plantdb.commons.db.Scan
         Calibration scan dataset to use (for camera poses).
     """
-    import toml
+    import tomlkit
     calib_backup_cfg = join(calibration_scan.path(), 'pipeline.toml')
     with open(calib_backup_cfg, 'r') as f:
-        calib_scan_cfg = toml.load(f)
+        calib_scan_cfg = tomlkit.load(f)
     # Inform whether the backup config was found or not
     if calib_scan_cfg == {}:
         logger.critical(f"Could not obtain valid backup config from {calibration_scan.id}!")

--- a/plant3dvision/tasks/proc2d.py
+++ b/plant3dvision/tasks/proc2d.py
@@ -181,9 +181,6 @@ class Undistort(ParallelFileTask):
     intrinsic_calib_scan_id = luigi.Parameter(default="")  # ID of scan containing intrinsic calibration
     extrinsic_calib_scan_id = luigi.Parameter(default="")  # ID of scan containing extrinsic calibration
 
-    n_workers = luigi.IntParameter(default=None)
-    parallel = luigi.BoolParameter(default=True)
-
     def requires(self):
         """Determines the dependencies required for the task execution."""
         from plant3dvision.tasks.calibration import ExtrinsicCalibrationExists

--- a/plant3dvision/tasks/proc2d.py
+++ b/plant3dvision/tasks/proc2d.py
@@ -129,16 +129,16 @@ class Undistort(ParallelFileTask):
     parallel : luigi.BoolParameter, optional
         Flag to enable/disable parallel processing.
         Defaults to ``True``.
-    camera_model_src : luigi.Parameter, optional
+    upstream_camera_model : luigi.Parameter, optional
         Source of the camera model, can be in ['Colmap', 'IntrinsicCalibration', 'ExtrinsicCalibration']
     camera_model : luigi.Parameter, optional
-        Name of the camera model to get if `camera_model_src='IntrinsicCalibration'`.
+        Name of the camera model to get if `upstream_camera_model='IntrinsicCalibration'`.
     intrinsic_calib_scan_id : luigi.Parameter, optional
         Name of the intrinsic calibration scan (dataset) to use. 
-        Used only if  `camera_model_src='IntrinsicCalibration'`.
+        Used only if `upstream_camera_model='IntrinsicCalibration'`.
     extrinsic_calib_scan_id : luigi.Parameter, optional
         Name of the extrinsic calibration scan (dataset) to use.
-        Used only if  `camera_model_src='ExtrinsicCalibration'`.
+        Used only if `upstream_camera_model='ExtrinsicCalibration'`.
 
     Returns
     -------
@@ -174,7 +174,7 @@ class Undistort(ParallelFileTask):
     upstream_task = luigi.TaskParameter(default=ImagesFilesetExists)
 
     # Parameter to specify source of camera calibration data
-    camera_model_src = luigi.Parameter("Colmap")  # Options: Colmap, IntrinsicCalibration, ExtrinsicCalibration
+    upstream_camera_model = luigi.Parameter("Colmap")  # Options: Colmap, IntrinsicCalibration, ExtrinsicCalibration
 
     # Parameters for intrinsic calibration
     camera_model = luigi.Parameter(default="SIMPLE_RADIAL")  # Camera model type for intrinsic calibration
@@ -190,7 +190,7 @@ class Undistort(ParallelFileTask):
         from plant3dvision.tasks.calibration import IntrinsicCalibrationExists
 
         # Validate configuration for intrinsic calibration
-        if self.extrinsic_calib_scan_id == "" and str(self.camera_model_src).lower() == 'intrinsiccalibration':
+        if self.extrinsic_calib_scan_id == "" and str(self.upstream_camera_model).lower() == 'intrinsiccalibration':
             logger.critical(
                 "If you use an IntrinsicCalibration as source for camera model, you have to define `extrinsic_calib_scan_id`!")
             sys.exit("Missing poses estimation in IntrinsicCalibration.")
@@ -203,10 +203,10 @@ class Undistort(ParallelFileTask):
             extrinsic_calib_scan = ExtrinsicCalibrationExists(scan_id=self.extrinsic_calib_scan_id)
 
         # Return required tasks based on camera model source
-        if str(self.camera_model_src).lower() == 'intrinsiccalibration':
+        if str(self.upstream_camera_model).lower() == 'intrinsiccalibration':
             logger.info(f"Using intrinsic calibration scan: {self.intrinsic_calib_scan_id}...")
             return {"camera": intrinsic_calib_scan, "images": self.upstream_task()}
-        elif str(self.camera_model_src).lower() == 'extrinsiccalibration':
+        elif str(self.upstream_camera_model).lower() == 'extrinsiccalibration':
             logger.info(f"Using extrinsic calibration scan: {self.extrinsic_calib_scan_id}...")
             return {"camera": extrinsic_calib_scan, "images": self.upstream_task()}
         else:
@@ -242,21 +242,21 @@ class Undistort(ParallelFileTask):
         colmap_camera = None
 
         # Handle intrinsic calibration case
-        if str(self.camera_model_src).lower() == 'intrinsiccalibration':
+        if str(self.upstream_camera_model).lower() == 'intrinsiccalibration':
             from plant3dvision.camera import get_camera_params_from_arrays
             from plant3dvision.camera import colmap_params_from_kwargs
             camera_params = get_camera_params_from_arrays(self.camera_model)
             params = colmap_params_from_kwargs(**camera_params)
             colmap_camera = {"camera_model": {"camera_model": self.camera_model, "params": params}}
         # Handle extrinsic calibration case
-        elif str(self.camera_model_src).lower() == 'extrinsiccalibration':
+        elif str(self.upstream_camera_model).lower() == 'extrinsiccalibration':
             from plant3dvision.camera import get_camera_arrays_from_params
             colmap_camera, poses = self.input()['camera']
 
         # Store these for use in the f method
         self._poses = poses
         self._colmap_camera = colmap_camera
-        self._camera_model_src = self.camera_model_src
+        self._upstream_camera_model = self.upstream_camera_model
 
         # Let the parent class handle the parallel execution
         super().run(self.input()['images'].get(), self.output().get())
@@ -313,12 +313,12 @@ class Undistort(ParallelFileTask):
             if hasattr(self, '_poses') and self._poses is not None:
                 fi.set_metadata({'calibrated_pose': self._poses[fi.id]})
             if hasattr(self, '_colmap_camera'):
-                if str(self._camera_model_src).lower() == 'intrinsiccalibration':
+                if str(self._upstream_camera_model).lower() == 'intrinsiccalibration':
                     fi.set_metadata({'colmap_camera': self._colmap_camera})
-                elif str(self._camera_model_src).lower() == 'extrinsiccalibration':
+                elif str(self._upstream_camera_model).lower() == 'extrinsiccalibration':
                     fi.set_metadata({'colmap_camera': self._colmap_camera[fi.id]})
 
-            md = {'upstream_task': str(self.upstream_task), "Camera model source": str(self.camera_model_src)}
+            md = {'upstream_task': str(self.upstream_task), "Camera model source": str(self.upstream_camera_model)}
             outfi.set_metadata(md)
             return outfi
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     # "pybind11",
     "pyopencl",
     "scikit-image",
-    "toml",
+    "tomlkit",
     "joblib",
     "matplotlib",
     "dash",


### PR DESCRIPTION
- Updated the `romitask` submodule to allow task cleaning with hierarchy awareness.
- Replaced the `toml` dependency with `tomlkit` across the project.  
- Removed the redeclared `n_workers` and `parallel` parameters from `proc2d.py`. 
- Renamed the configuration key `camera_model_src` to `upstream_camera_model` in all pipeline TOML files (`fast_geom_pipe_real.toml`, `ml_pipe_full.toml`, `geom_pipe_full.toml`).
- Refactored `proc2d.py` to adopt the new `upstream_camera_model` parameter, updating signatures, internal attributes, validation logic, logging, and documentation accordingly.