### PR TITLE
Linear Filter: Add channel spinboxes and improve docs

### DIFF
--- a/plant3dvision/gui/linear_filter.py
+++ b/plant3dvision/gui/linear_filter.py
@@ -2,20 +2,22 @@
 # -*- coding: utf-8 -*-
 
 """
-**RGB Linear Filter GUI**
+**Linear Filter GUI**
 
 A Python module that launches an interactive Qt‑based application for loading plant scan images, applying a customizable linear combination of color‑space channels, and visualizing the filtered result together with a threshold‑derived binary mask.
 It streamlines the exploration of channel weighting and threshold parameters, making it easy to fine‑tune image preprocessing for downstream analysis.
 
 ## Key Features
 
+- List scans from a PlantDB (FSDB).
+- Search and filter scans via a searchable dropdown.
 - Load images from a PlantDB (FSDB) scan.
 - Select among three color spaces (RGB, HSV, YCbCr) and adjust each channel’s contribution with sliders.
 - Real‑time preview of the original image, the filtered grayscale image, and the binary mask.
 - Interactive threshold controls (min / max) and optional binary dilation.
 - Synchronized pan/zoom across all three sub‑plots, with mouse‑wheel zoom support.
 - Export the current filter parameters to a `local_config.toml` file attached to the chosen scan.
-- Search and filter scans via a searchable dropdown.
+- Load existing filter parameters from a `local_config.toml` attached to the chosen scan, if any.
 
 ## Usage Examples
 

--- a/plant3dvision/gui/linear_filter.py
+++ b/plant3dvision/gui/linear_filter.py
@@ -82,8 +82,55 @@ class RGBFilterApp(QMainWindow):
     mask : numpy.ndarray
         Boolean mask where ``True`` indicates pixel values within the chosen
         threshold range.
-    ch1_value, ch2_value, ch3_value : PySide6.QtWidgets.QLabel
-        Labels that display the current scaling factors for the three channels.
+    fsdb_path : str | Path
+        Path to the FSDB database.
+    db : FSDB or None
+        Database connection instance.
+    scan_ids_list : list of str
+        List of scan identifiers loaded from the database.
+    images_list : list
+        List of image files in the current scan.
+    current_scan : Scan or None
+        Currently selected scan object.
+    ch1_value, ch2_value, ch3_value : QDoubleSpinBox
+        Spin boxes that display and allow precise entry of the scaling factors
+        for the three channels.
+    ch1_slider, ch2_slider, ch3_slider : QSlider
+        Sliders controlling the weighting of each channel (0–100).
+    ch1_label, ch2_label, ch3_label : QLabel
+        Labels identifying each channel (change with color space).
+    color_space_combo : QComboBox
+        Dropdown to select the active color space (RGB, HSV, YCbCr).
+    cs_help_button : QPushButton
+        Button that opens the color space help dialog.
+    min_threshold_spinbox : QDoubleSpinBox
+        Spin box for the minimum threshold value.
+    max_threshold_spinbox : QDoubleSpinBox
+        Spin box for the maximum threshold value.
+    dilation_spinbox : QDoubleSpinBox
+        Spin box for the number of binary dilation iterations.
+    export_button : QPushButton
+        Button to export current parameters to ``local_config.toml``.
+    search_box : QLineEdit
+        Text field to filter the scan dropdown.
+    scan_dropdown : QComboBox
+        Dropdown listing all available scans.
+    image_slider : QSlider
+        Slider to pick an image from the current scan.
+    image_index_spinbox : QDoubleSpinBox
+        Spin box showing the current image index (1‑based) out of the total.
+    figure : matplotlib.figure.Figure
+        Matplotlib figure holding the three sub‑plots.
+    canvas : FigureCanvas
+        Matplotlib canvas embedded in the Qt window.
+    toolbar : NavigationToolbar
+        Matplotlib navigation toolbar (pan, zoom, home, save).
+    _load_image_timer : QTimer
+        Single‑shot timer (300 ms) that triggers image loading after the
+        slider stops changing.
+    _process_image_timer : QTimer
+        Single‑shot timer (300 ms) that triggers filter processing after
+        any parameter change.
     """
 
     def __init__(self, fsdb_path: str | Path, scan_id: str | None):

--- a/plant3dvision/gui/linear_filter.py
+++ b/plant3dvision/gui/linear_filter.py
@@ -243,7 +243,11 @@ class RGBFilterApp(QMainWindow):
         self.ch1_slider.setToolTip(
             "Adjust the weighting of the first channel."
         )
-        self.ch1_value = QLabel("0.5")
+        self.ch1_value = QDoubleSpinBox()
+        self.ch1_value.setDecimals(2)
+        self.ch1_value.setRange(0.0, 1.0)
+        self.ch1_value.setSingleStep(0.01)
+        self.ch1_value.setValue(0.5)
         ch1_layout.addWidget(self.ch1_label)
         ch1_layout.addWidget(self.ch1_slider)
         ch1_layout.addWidget(self.ch1_value)
@@ -263,7 +267,11 @@ class RGBFilterApp(QMainWindow):
         self.ch2_slider.setToolTip(
             "Adjust the weighting of the second channel."
         )
-        self.ch2_value = QLabel("1.0")
+        self.ch2_value = QDoubleSpinBox()
+        self.ch2_value.setDecimals(2)
+        self.ch2_value.setRange(0.0, 1.0)
+        self.ch2_value.setSingleStep(0.01)
+        self.ch2_value.setValue(1.0)
         ch2_layout.addWidget(self.ch2_label)
         ch2_layout.addWidget(self.ch2_slider)
         ch2_layout.addWidget(self.ch2_value)
@@ -283,7 +291,11 @@ class RGBFilterApp(QMainWindow):
         self.ch3_slider.setToolTip(
             "Adjust the weighting of the third channel."
         )
-        self.ch3_value = QLabel("0.5")
+        self.ch3_value = QDoubleSpinBox()
+        self.ch3_value.setDecimals(2)
+        self.ch3_value.setRange(0.0, 1.0)
+        self.ch3_value.setSingleStep(0.01)
+        self.ch3_value.setValue(0.5)
         ch3_layout.addWidget(self.ch3_label)
         ch3_layout.addWidget(self.ch3_slider)
         ch3_layout.addWidget(self.ch3_value)
@@ -377,10 +389,13 @@ class RGBFilterApp(QMainWindow):
         # Connect signals
         self.ch1_slider.valueChanged.connect(self.update_ch1_value)
         self.ch1_slider.valueChanged.connect(self._process_image_timer.start)
+        self.ch1_value.valueChanged.connect(self._on_ch1_spinbox_changed)
         self.ch2_slider.valueChanged.connect(self.update_ch2_value)
         self.ch2_slider.valueChanged.connect(self._process_image_timer.start)
+        self.ch2_value.valueChanged.connect(self._on_ch2_spinbox_changed)
         self.ch3_slider.valueChanged.connect(self.update_ch3_value)
         self.ch3_slider.valueChanged.connect(self._process_image_timer.start)
+        self.ch3_value.valueChanged.connect(self._on_ch3_spinbox_changed)
         self.color_space_combo.currentTextChanged.connect(self._process_image_timer.start)
         self.min_threshold_spinbox.valueChanged.connect(self._process_image_timer.start)
         self.max_threshold_spinbox.valueChanged.connect(self._process_image_timer.start)
@@ -592,7 +607,9 @@ class RGBFilterApp(QMainWindow):
             Slider position in the range ``0``–``100``.
             The displayed coefficient is ``value / 100``.
         """
-        self.ch1_value.setText(f"{value / 100:.2f}")
+        self.ch1_value.blockSignals(True)
+        self.ch1_value.setValue(value / 100.0)
+        self.ch1_value.blockSignals(False)
 
     def update_ch2_value(self, value):
         """Refresh the displayed value for channel 2.
@@ -602,7 +619,9 @@ class RGBFilterApp(QMainWindow):
         value : int
             Slider position in the range ``0``–``100``.
         """
-        self.ch2_value.setText(f"{value / 100:.2f}")
+        self.ch2_value.blockSignals(True)
+        self.ch2_value.setValue(value / 100.0)
+        self.ch2_value.blockSignals(False)
 
     def update_ch3_value(self, value):
         """Refresh the displayed value for channel 3.
@@ -613,7 +632,33 @@ class RGBFilterApp(QMainWindow):
             Slider position in the range ``0``–``100``.
 
         """
-        self.ch3_value.setText(f"{value / 100:.2f}")
+        self.ch3_value.blockSignals(True)
+        self.ch3_value.setValue(value / 100.0)
+        self.ch3_value.blockSignals(False)
+
+    @Slot()
+    def _on_ch1_spinbox_changed(self, value):
+        """Update the channel 1 slider when the spinbox value changes."""
+        self.ch1_slider.blockSignals(True)
+        self.ch1_slider.setValue(int(value * 100))
+        self.ch1_slider.blockSignals(False)
+        self._process_image_timer.start()
+
+    @Slot()
+    def _on_ch2_spinbox_changed(self, value):
+        """Update the channel 2 slider when the spinbox value changes."""
+        self.ch2_slider.blockSignals(True)
+        self.ch2_slider.setValue(int(value * 100))
+        self.ch2_slider.blockSignals(False)
+        self._process_image_timer.start()
+
+    @Slot()
+    def _on_ch3_spinbox_changed(self, value):
+        """Update the channel 3 slider when the spinbox value changes."""
+        self.ch3_slider.blockSignals(True)
+        self.ch3_slider.setValue(int(value * 100))
+        self.ch3_slider.blockSignals(False)
+        self._process_image_timer.start()
 
     def load_image_from_path(self, file_path: str) -> None:
         """Load an image from an absolute path (used for CLI start‑up).


### PR DESCRIPTION

* Replaced channel value `QLabel`s with `QDoubleSpinBox` widgets (`ch1_value`, `ch2_value`, `ch3_value`) supporting a 0.0‑1.0 range, two decimal places, and appropriate defaults.
* Connected each spinbox’s `valueChanged` signal to new slots (`_on_ch*_spinbox_changed`) that synchronize the corresponding slider position and trigger image processing.
* Updated the `update_ch*_value` methods to set spinbox values (with signal blocking) instead of updating label text, preventing feedback loops.
* Adjusted the UI layout to place the new spinboxes alongside the existing sliders and labels.
* Expanded the docstring in `plant3dvision/gui/linear_filter.py` to document new attributes and UI components, including FSDB integration, navigation controls, Matplotlib figure handling, and timers.