### PR TITLE
Sort bounding box ranges before computing shape and origin

### DIFF
--- a/plant3dvision/tasks/voxel_reconstruction.py
+++ b/plant3dvision/tasks/voxel_reconstruction.py
@@ -66,9 +66,9 @@ def shape_from_bounding_box(bounding_box: dict[str, tuple[int, int]], voxel_size
     >>> print(shape_from_bounding_box(bounding_box, voxel_size))
     (271, 271, 721)
     """
-    (x_min, x_max) = bounding_box["x"]
-    (y_min, y_max) = bounding_box["y"]
-    (z_min, z_max) = bounding_box["z"]
+    x_min, x_max = sorted(bounding_box["x"])
+    y_min, y_max = sorted(bounding_box["y"])
+    z_min, z_max = sorted(bounding_box["z"])
     nx = int((x_max - x_min) / voxel_size) + 1
     ny = int((y_max - y_min) / voxel_size) + 1
     nz = int((z_max - z_min) / voxel_size) + 1
@@ -109,9 +109,9 @@ def origin_from_bounding_box(bounding_box: dict[str, tuple[int, int]], voxel_siz
     >>> print(origin_from_bounding_box(bounding_box, voxel_size)) # to get it in voxel units
     (600.0, 600.0, -600.0)
     """
-    (x_min, x_max) = bounding_box["x"]
-    (y_min, y_max) = bounding_box["y"]
-    (z_min, z_max) = bounding_box["z"]
+    x_min, x_max = sorted(bounding_box["x"])
+    y_min, y_max = sorted(bounding_box["y"])
+    z_min, z_max = sorted(bounding_box["z"])
     return tuple(map(float, np.array([x_min, y_min, z_min]) / float(voxel_size)))
 
 


### PR DESCRIPTION
Implemented sorting of bounding box coordinate ranges to ensure correct minimum and maximum ordering:

- Updated `shape_from_bounding_box` in `plant3dvision/tasks/voxel_reconstruction.py` to use `sorted(...)` on `bounding_box["x"]`, `["y"]`, and `["z"]`.
- Applied the same sorting logic in `origin_from_bounding_box` for consistent origin calculation.
- Guarantees accurate voxel dimensions and origin even when input ranges are reversed.